### PR TITLE
fix: ensure spinner messages show proper TASK level with prefix and t…

### DIFF
--- a/.github/workflows/demo-test.yml
+++ b/.github/workflows/demo-test.yml
@@ -214,4 +214,3 @@ jobs:
             echo "✅ CI detection disabled - should use default behavior"
           fi
           echo "🎯 CI detection behavior validated for ${{ matrix.ci-detection }} mode"
- 

--- a/.github/workflows/demo-test.yml
+++ b/.github/workflows/demo-test.yml
@@ -214,3 +214,4 @@ jobs:
             echo "✅ CI detection disabled - should use default behavior"
           fi
           echo "🎯 CI detection behavior validated for ${{ matrix.ci-detection }} mode"
+ 

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,10 @@ dist/
 build/
 *.tsbuildinfo
 
+# Build artifacts in examples
+examples/src/
+examples/examples/*.js
+
 # Documentation
 docs/
 
@@ -46,6 +50,9 @@ pids/
 # Temporary files
 tmp/
 temp/
+
+# Debug scripts
+debug-*.js
 
 # Claude Code
 CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -45,4 +45,7 @@ pids/
 
 # Temporary files
 tmp/
-temp/ 
+temp/
+
+# Claude Code
+CLAUDE.md 

--- a/.gitignore
+++ b/.gitignore
@@ -48,4 +48,5 @@ tmp/
 temp/
 
 # Claude Code
-CLAUDE.md 
+CLAUDE.md
+.claude

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,3 +91,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON output mode
 - Terminal capability detection
 - CI/CD friendly output
+ 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -91,4 +91,3 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - JSON output mode
 - Terminal capability detection
 - CI/CD friendly output
- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,4 +303,3 @@ npm test -- --reporter=verbose
 - **Documentation**: [API Docs](https://neoforkdev.github.io/devlogr/)
 
 Thank you for contributing to DevLogr! 🚀
- 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,3 +303,4 @@ npm test -- --reporter=verbose
 - **Documentation**: [API Docs](https://neoforkdev.github.io/devlogr/)
 
 Thank you for contributing to DevLogr! 🚀
+ 

--- a/README.md
+++ b/README.md
@@ -193,20 +193,18 @@ npm run docs:serve  # serve locally
 
 Configure behavior via env vars:
 
-| Variable                             | Description                       | Example       |
-| ------------------------------------ | --------------------------------- | ------------- |
-| `DEVLOGR_LOG_LEVEL`                  | Minimum log level (`debug`, etc.) | `debug`       |
-| `DEVLOGR_OUTPUT_JSON`                | Structured JSON logs              | `true`        |
-| `DEVLOGR_SHOW_TIMESTAMP`             | Enables timestamps                | `true`/`iso`  |
-| `DEVLOGR_SHOW_PREFIX`                | Show level prefixes & logger name | `true`        |
-| `DEVLOGR_DISABLE_CI_DETECTION`       | Disable automatic CI optimization | `true`        |
-| `DEVLOGR_NO_COLOR`                   | Disable colors                    | `true`        |
-| `DEVLOGR_FORCE_COLOR`                | Force colors                      | `true`        |
-| `DEVLOGR_NO_EMOJI`                   | Disable emojis                    | `true`        |
-| `DEVLOGR_NO_UNICODE`                 | ASCII-only mode                   | `true`        |
-| `DEVLOGR_UNICODE`                    | Force Unicode support             | `true`/`auto` |
-| `DEVLOGR_NO_ICONS`                   | Hide all icons                    | `true`        |
-| `NO_COLOR`, `NO_EMOJI`, `NO_UNICODE` | Global disable standards          | `1`           |
+| Variable                             | Description                       | Example      |
+| ------------------------------------ | --------------------------------- | ------------ |
+| `DEVLOGR_LOG_LEVEL`                  | Minimum log level (`debug`, etc.) | `debug`      |
+| `DEVLOGR_OUTPUT_JSON`                | Structured JSON logs              | `true`       |
+| `DEVLOGR_SHOW_TIMESTAMP`             | Show timestamps                   | `true`/`iso` |
+| `DEVLOGR_SHOW_PREFIX`                | Show level prefixes & logger name | `true`       |
+| `DEVLOGR_SHOW_COLOR`                 | Enable colors                     | `true`       |
+| `DEVLOGR_SHOW_EMOJI`                 | Enable emojis                     | `true`       |
+| `DEVLOGR_SHOW_UNICODE`               | Enable Unicode symbols            | `true`       |
+| `DEVLOGR_SHOW_ICONS`                 | Show all icons                    | `true`       |
+| `DEVLOGR_DISABLE_CI_DETECTION`       | Disable automatic CI optimization | `true`       |
+| `NO_COLOR`, `NO_EMOJI`, `NO_UNICODE` | Global disable standards          | `1`          |
 
 ---
 

--- a/examples/ci-detection.ts
+++ b/examples/ci-detection.ts
@@ -71,37 +71,33 @@ async function demonstrateCIDetection() {
   logger.separator('Benefits in CI');
   logger.spacer();
 
-  if (isCI) {
-    logger.success('CI environment detected! DevLogR automatically configured for:');
-    logger.info('  📝 Better log identification with prefixes');
-    logger.info('  ⏰ Timestamps for debugging and correlation');
-    logger.info('  🎯 No icons for maximum compatibility');
-    logger.info('  🌈 Dynamic color support based on CI capabilities');
-    logger.info('  😊 Smart emoji detection');
-  } else {
-    logger.info('Not running in CI - using terminal-optimized settings');
-    logger.info('To test CI mode, set CI=true environment variable');
-  }
+  // Show benefits
+  logger.success('CI environment detected! DevLogR automatically configured for:');
+  logger.info('  📝 Better log identification with prefixes');
+  logger.info('  ⏰ Timestamps for debugging and correlation');
+  logger.info('  🎯 No icons for maximum compatibility');
+  logger.info('  🌈 Dynamic color support based on CI capabilities');
+  logger.info('  😊 Smart emoji detection');
 
   logger.spacer();
   logger.separator('CI Detection Control');
   logger.spacer();
 
-  const ciDetectionDisabled = process.env.DEVLOGR_DISABLE_CI_DETECTION === 'true';
-  if (ciDetectionDisabled) {
-    logger.warning('🚫 CI Detection is DISABLED via DEVLOGR_DISABLE_CI_DETECTION=true');
+  // Show control options
+  const isDisabled = process.env.DEVLOGR_DISABLE_CI_DETECTION === 'true';
+  if (isDisabled) {
+    logger.warn('🚫 CI Detection is DISABLED via DEVLOGR_DISABLE_CI_DETECTION=true');
     logger.info('Using default (non-CI) behavior regardless of CI environment');
   } else {
     logger.info('✅ CI Detection is ENABLED (default behavior)');
-    if (isCI) {
-      logger.info('Applying CI-optimized settings automatically');
-    }
+    logger.info('Applying CI-optimized settings automatically');
   }
 
   logger.spacer();
   logger.separator('Override Examples');
   logger.spacer();
 
+  // Show override options
   logger.info('You can control CI detection and override defaults:');
   logger.plain('  DEVLOGR_DISABLE_CI_DETECTION=true  # Disable CI detection entirely');
   logger.plain('  DEVLOGR_SHOW_PREFIX=false          # Disable prefixes even in CI');
@@ -111,6 +107,28 @@ async function demonstrateCIDetection() {
   logger.plain('  DEVLOGR_NO_EMOJI=true              # Disable emoji specifically');
 
   logger.spacer();
+
+  // NEW: Demonstrate spinner behavior in CI
+  if (isCI) {
+    logger.separator('Spinner Behavior in CI');
+    logger.spacer();
+
+    logger.info('Testing spinner with prefix and timestamp in CI...');
+
+    // Start a spinner to show it works with prefixes and timestamps
+    logger.startSpinner('Processing CI deployment...');
+
+    // Simulate some work
+    await new Promise(resolve => setTimeout(resolve, 1000));
+
+    // Complete the spinner
+    logger.succeedSpinner('CI deployment completed successfully!');
+
+    logger.spacer();
+    logger.info('✅ Spinner correctly shows prefix and timestamp in CI environment');
+    logger.spacer();
+  }
+
   logger.title('✅ CI Detection Demo Complete');
 }
 

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -121,64 +121,8 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
-async function duplicateTest() {
-  console.log('\n\n' + '='.repeat(60));
-  console.log('SPINNER TEST - Testing the new dual system:');
-  console.log('='.repeat(60));
-
-  const testLogger = new Logger('test');
-
-  // Test scenario that might produce duplicates
-  console.log('\n--- Test 1: Simple spinner success ---');
-  testLogger.startSpinner('Processing...');
-  await sleep(500);
-  await testLogger.succeedSpinner('Operation completed successfully');
-
-  await sleep(200);
-
-  console.log('\n--- Test 2: Rapid fire spinners (should work fine) ---');
-  for (let i = 1; i <= 3; i++) {
-    testLogger.startSpinner(`Step ${i}...`);
-    await sleep(100);
-    testLogger.succeedSpinner(`Step ${i} completed`);
-    await sleep(50); // Small delay to ensure completion
-  }
-
-  console.log('\n--- Test 2b: Error case - starting spinner while active ---');
-  const errorTestLogger = new Logger('error-test');
-  try {
-    errorTestLogger.startSpinner('First spinner...');
-    errorTestLogger.startSpinner('Second spinner...');
-    console.log('❌ ERROR: Second spinner should not have started!');
-  } catch (error) {
-    console.log('✅ Expected error caught:', (error as Error).message);
-  }
-  if (errorTestLogger.isSpinnerActive()) {
-    await errorTestLogger.failSpinner('First spinner failed due to error test');
-  }
-  await sleep(300);
-
-  console.log('\n--- Test 3: Mixed completion types ---');
-  testLogger.startSpinner('Building...');
-  await sleep(200);
-  await testLogger.succeedSpinner('Build completed');
-
-  testLogger.startSpinner('Testing...');
-  await sleep(200);
-  await testLogger.failSpinner('Tests failed');
-
-  testLogger.startSpinner('Deploying...');
-  await sleep(200);
-  await testLogger.warnSpinner('Deployment warning');
-
-  console.log('\n' + '='.repeat(60));
-  console.log('END SPINNER TEST - Single spinners use ora, multi-spinners use Listr2');
-  console.log('='.repeat(60) + '\n');
-}
-
 async function main() {
   await quickDemo();
-  await duplicateTest();
 }
 
 // Run the demo

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -107,7 +107,7 @@ async function quickDemo() {
   // Cleanup with a minor warning
   logger.startSpinner('Running cleanup tasks...');
   await sleep(1000);
-  await logger.warnSpinner('Cleanup completed with minor warnings');
+  logger.warnSpinner('Cleanup completed with minor warnings');
 
   await sleep(300);
 

--- a/examples/demo.ts
+++ b/examples/demo.ts
@@ -22,7 +22,7 @@ async function quickDemo() {
   await sleep(1000);
   logger.updateSpinnerText('Checking permissions...');
   await sleep(800);
-  logger.succeedSpinner('Pre-deployment checks passed');
+  await logger.succeedSpinner('Pre-deployment checks passed');
 
   await sleep(400);
 
@@ -39,7 +39,7 @@ async function quickDemo() {
   await sleep(900);
   logger.updateSpinnerText('Processing assets...');
   await sleep(700);
-  logger.succeedSpinner('Build completed (3.2s)');
+  await logger.succeedSpinner('Build completed (3.2s)');
 
   await sleep(300);
 
@@ -107,7 +107,7 @@ async function quickDemo() {
   // Cleanup with a minor warning
   logger.startSpinner('Running cleanup tasks...');
   await sleep(1000);
-  logger.warnSpinner('Cleanup completed with minor warnings');
+  await logger.warnSpinner('Cleanup completed with minor warnings');
 
   await sleep(300);
 
@@ -121,5 +121,65 @@ function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
 
+async function duplicateTest() {
+  console.log('\n\n' + '='.repeat(60));
+  console.log('SPINNER TEST - Testing the new dual system:');
+  console.log('='.repeat(60));
+
+  const testLogger = new Logger('test');
+
+  // Test scenario that might produce duplicates
+  console.log('\n--- Test 1: Simple spinner success ---');
+  testLogger.startSpinner('Processing...');
+  await sleep(500);
+  await testLogger.succeedSpinner('Operation completed successfully');
+
+  await sleep(200);
+
+  console.log('\n--- Test 2: Rapid fire spinners (should work fine) ---');
+  for (let i = 1; i <= 3; i++) {
+    testLogger.startSpinner(`Step ${i}...`);
+    await sleep(100);
+    testLogger.succeedSpinner(`Step ${i} completed`);
+    await sleep(50); // Small delay to ensure completion
+  }
+
+  console.log('\n--- Test 2b: Error case - starting spinner while active ---');
+  const errorTestLogger = new Logger('error-test');
+  try {
+    errorTestLogger.startSpinner('First spinner...');
+    errorTestLogger.startSpinner('Second spinner...');
+    console.log('❌ ERROR: Second spinner should not have started!');
+  } catch (error) {
+    console.log('✅ Expected error caught:', (error as Error).message);
+  }
+  if (errorTestLogger.isSpinnerActive()) {
+    await errorTestLogger.failSpinner('First spinner failed due to error test');
+  }
+  await sleep(300);
+
+  console.log('\n--- Test 3: Mixed completion types ---');
+  testLogger.startSpinner('Building...');
+  await sleep(200);
+  await testLogger.succeedSpinner('Build completed');
+
+  testLogger.startSpinner('Testing...');
+  await sleep(200);
+  await testLogger.failSpinner('Tests failed');
+
+  testLogger.startSpinner('Deploying...');
+  await sleep(200);
+  await testLogger.warnSpinner('Deployment warning');
+
+  console.log('\n' + '='.repeat(60));
+  console.log('END SPINNER TEST - Single spinners use ora, multi-spinners use Listr2');
+  console.log('='.repeat(60) + '\n');
+}
+
+async function main() {
+  await quickDemo();
+  await duplicateTest();
+}
+
 // Run the demo
-quickDemo().catch(console.error);
+main().catch(console.error);

--- a/examples/json-output.ts
+++ b/examples/json-output.ts
@@ -2,7 +2,7 @@ import { Logger } from '../src/logger';
 import { LogLevel } from '../src/types';
 
 // Force JSON mode for this demo
-process.env.LOG_JSON = 'true';
+process.env.DEVLOGR_OUTPUT_JSON = 'true';
 
 const logger = new Logger('JsonDemo');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
   "name": "@neofork/devlogr",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@neofork/devlogr",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "MIT",
       "dependencies": {
         "chalk": "^4.1.2",
-        "listr2": "^8.3.3"
+        "listr2": "^8.3.3",
+        "ora": "^5.4.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",
@@ -1627,7 +1628,6 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -1670,6 +1670,37 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
     "node_modules/brace-expansion": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
@@ -1692,6 +1723,30 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/cac": {
@@ -1792,6 +1847,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-spinners": {
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/cli-truncate": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-4.0.0.tgz",
@@ -1806,6 +1873,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/clone": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/clone/-/clone-1.0.4.tgz",
+      "integrity": "sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/color-convert": {
@@ -1908,6 +1984,18 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/defaults": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/defaults/-/defaults-1.0.4.tgz",
+      "integrity": "sha512-eFuaLoy/Rxalv2kr+lqMlUnrDWV+3j4pljOIJgLIhI058IQfWJ7vXhyEIHu+HtC738klGALYxOKDO0bQP3tg8A==",
+      "license": "MIT",
+      "dependencies": {
+        "clone": "^1.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -2541,6 +2629,26 @@
         "url": "https://github.com/sponsors/typicode"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -2594,7 +2702,6 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-extglob": {
@@ -2632,6 +2739,15 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-interactive": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-interactive/-/is-interactive-1.0.0.tgz",
+      "integrity": "sha512-2HvIEKRoqS62guEC+qBjpvRubdX910WCMuJTZ+I9yvqKU2/12eSL549HMwtabb4oupdj2sMP50k+XJfB/8JE6w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-number": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -2660,6 +2776,18 @@
       "license": "MIT",
       "engines": {
         "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/is-unicode-supported": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
+      "integrity": "sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -2911,6 +3039,22 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-symbols": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-4.1.0.tgz",
+      "integrity": "sha512-8XPvpAA8uyhfteu8pIvQxpJZ7SYYdpUivZpGy6sFsBuKRY/7rQGavedeB8aK+Zkyq6upMFVL/9AW6vOYzfRyLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "is-unicode-supported": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/log-update": {
       "version": "6.1.0",
@@ -3275,6 +3419,84 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/ora": {
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-5.4.1.tgz",
+      "integrity": "sha512-5b6Y85tPxZZ7QytO+BQzysW31HJku27cRIlkbAXaNx+BdcVi+LlRFmVXzeF6a7JCwJpyw5c4b+YSVImQIrBpuQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.1.0",
+        "chalk": "^4.1.0",
+        "cli-cursor": "^3.1.0",
+        "cli-spinners": "^2.5.0",
+        "is-interactive": "^1.0.0",
+        "is-unicode-supported": "^0.1.0",
+        "log-symbols": "^4.1.0",
+        "strip-ansi": "^6.0.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/cli-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-3.1.0.tgz",
+      "integrity": "sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==",
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/mimic-fn": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/ora/node_modules/onetime": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
+      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-fn": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/ora/node_modules/restore-cursor": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
+      "integrity": "sha512-l+sSefzHpj5qimhFSE5a8nufZYAM3sBSVMAPtYkmC+4EH2anSGaEMXSD0izRQbu9nfyQ9y5JrVmp7E8oZrUjvA==",
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^5.1.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ora/node_modules/signal-exit": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "license": "ISC"
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -3537,6 +3759,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
@@ -3671,6 +3907,26 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/semver": {
       "version": "7.7.2",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
@@ -3778,6 +4034,15 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "node_modules/string-argv": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
@@ -3836,7 +4101,6 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-regex": "^5.0.1"
@@ -4567,6 +4831,12 @@
         "punycode": "^2.1.0"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/vite": {
       "version": "5.4.19",
       "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.19.tgz",
@@ -4714,6 +4984,15 @@
         "jsdom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/wcwidth": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/wcwidth/-/wcwidth-1.0.1.tgz",
+      "integrity": "sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==",
+      "license": "MIT",
+      "dependencies": {
+        "defaults": "^1.0.3"
       }
     },
     "node_modules/which": {

--- a/package.json
+++ b/package.json
@@ -108,7 +108,8 @@
   },
   "dependencies": {
     "chalk": "^4.1.2",
-    "listr2": "^8.3.3"
+    "listr2": "^8.3.3",
+    "ora": "^5.4.1"
   },
   "engines": {
     "node": ">=16.0.0"

--- a/package.json
+++ b/package.json
@@ -48,17 +48,21 @@
   },
   "lint-staged": {
     "*.{ts,tsx}": [
+      "prettier --check",
       "prettier --write",
       "eslint --fix"
     ],
     "*.{js,mjs}": [
+      "prettier --check",
       "prettier --write",
       "eslint --fix"
     ],
     "*.{json,md,yml,yaml}": [
+      "prettier --check",
       "prettier --write"
     ],
     "package.json": [
+      "prettier --check",
       "prettier --write"
     ]
   },

--- a/scripts/test-by-category.ts
+++ b/scripts/test-by-category.ts
@@ -1,9 +1,13 @@
 #!/usr/bin/env node
 
-const { execSync } = require('child_process');
-const path = require('path');
+import { execSync } from 'child_process';
 
-const categories = {
+interface TestCategory {
+  path: string;
+  description: string;
+}
+
+const categories: Record<string, TestCategory> = {
   core: {
     path: 'tests/core/',
     description: 'Core functionality tests (environment, integration, standards)',
@@ -26,9 +30,9 @@ const categories = {
   },
 };
 
-function showUsage() {
+function showUsage(): void {
   console.log('\n🧪 DevLogr Test Runner\n');
-  console.log('Usage: node scripts/test-by-category.js [category]\n');
+  console.log('Usage: npx tsx scripts/test-by-category.ts [category]\n');
   console.log('Available categories:\n');
 
   Object.entries(categories).forEach(([key, { description }]) => {
@@ -36,12 +40,12 @@ function showUsage() {
   });
 
   console.log('\nExamples:');
-  console.log('  node scripts/test-by-category.js core');
-  console.log('  node scripts/test-by-category.js spinner');
-  console.log('  node scripts/test-by-category.js --all\n');
+  console.log('  npx tsx scripts/test-by-category.ts core');
+  console.log('  npx tsx scripts/test-by-category.ts spinner');
+  console.log('  npx tsx scripts/test-by-category.ts --all\n');
 }
 
-function runTests(category) {
+function runTests(category: string): void {
   const config = categories[category];
   if (!config) {
     console.error(`❌ Unknown category: ${category}`);
@@ -58,16 +62,16 @@ function runTests(category) {
       cwd: process.cwd(),
     });
     console.log(`\n✅ ${category} tests completed successfully!\n`);
-  } catch (error) {
+  } catch (error: any) {
     console.log(`\n❌ ${category} tests failed with exit code ${error.status}\n`);
     process.exit(error.status);
   }
 }
 
-function runAllTests() {
+function runAllTests(): void {
   console.log('\n🚀 Running all test categories...\n');
 
-  const results = {};
+  const results: Record<string, string> = {};
 
   Object.keys(categories).forEach(category => {
     try {
@@ -77,7 +81,7 @@ function runAllTests() {
         cwd: process.cwd(),
       });
       results[category] = '✅ PASSED';
-    } catch (error) {
+    } catch (error: any) {
       results[category] = `❌ FAILED (${error.status})`;
     }
   });

--- a/scripts/test-global-standards.ts
+++ b/scripts/test-global-standards.ts
@@ -5,12 +5,18 @@
  * Run this script to verify that NO_COLOR, NO_EMOJI, and NO_UNICODE work correctly
  */
 
-const { createLogger } = require('../dist/logger.js');
-const { TerminalUtils } = require('../dist/utils/terminal.js');
-const { EmojiUtils } = require('../dist/utils/emoji.js');
+import { Logger } from '../src/logger';
+import { TerminalUtils } from '../src/utils';
+import { EmojiUtils } from '../src/utils/emoji';
+
+interface TestCase {
+  name: string;
+  setup: () => void;
+  expected: string;
+}
 
 // Helper to clear environment
-function clearEnv() {
+function clearEnv(): void {
   delete process.env.NO_COLOR;
   delete process.env.NO_EMOJI;
   delete process.env.NO_UNICODE;
@@ -23,7 +29,7 @@ function clearEnv() {
 }
 
 // Test cases
-const tests = [
+const tests: TestCase[] = [
   {
     name: 'Default behavior (no env vars)',
     setup: () => clearEnv(),
@@ -99,7 +105,7 @@ tests.forEach((test, index) => {
   );
 
   // Create a logger and test actual output
-  const logger = createLogger('TEST');
+  const logger = new Logger('TEST');
   console.log(`   Sample output:`);
   logger.info('Hello 🚀 World ℹ✓');
 });

--- a/src/adapters/ora-spinner.ts
+++ b/src/adapters/ora-spinner.ts
@@ -3,11 +3,7 @@ import { MessageFormatter } from '../formatters';
 import { SpinnerRenderer } from './spinner-renderer';
 
 /**
- * DevLogr spinner implementation following SOLID principles.
- * Coordinates between MessageFormatter (formatting) and SpinnerRenderer (display).
- * No environment detection logic - delegates to existing utilities.
- *
- * @implements {ISpinner}
+ * Spinner implementation that coordinates formatting and display.
  */
 export class OraSpinner implements ISpinner {
   private renderer: SpinnerRenderer;
@@ -19,22 +15,17 @@ export class OraSpinner implements ISpinner {
     this.renderer = new SpinnerRenderer();
   }
 
-  /**
-   * Set the logger prefix for consistent formatting across all DevLogr APIs
-   */
   setPrefix(prefix: string): void {
     this.prefix = prefix;
   }
 
   start(text: string): void {
-    this.stop(); // Ensure clean state
+    this.stop();
     this.currentMessage = text;
 
     if (SpinnerRenderer.shouldAnimate()) {
-      // TTY environment - start animation with proper formatting
       this.renderer.startAnimation(text, 'task', this.prefix);
     } else {
-      // CI environment - static output using MessageFormatter
       const formatted = MessageFormatter.formatSpinnerOutput(text, 'task', this.prefix, 'running');
       this.renderer.renderStatic(formatted.fullText);
     }
@@ -93,7 +84,6 @@ export class OraSpinner implements ISpinner {
   updateText(text: string): void {
     this.currentMessage = text;
     if (this.renderer.isCurrentlyAnimating()) {
-      // Update the animation with new message
       this.renderer.updateMessage(text);
     }
   }

--- a/src/adapters/ora-spinner.ts
+++ b/src/adapters/ora-spinner.ts
@@ -1,0 +1,104 @@
+import { ISpinner } from '../types/spinner';
+import { MessageFormatter } from '../formatters';
+import { SpinnerRenderer } from './spinner-renderer';
+
+/**
+ * DevLogr spinner implementation following SOLID principles.
+ * Coordinates between MessageFormatter (formatting) and SpinnerRenderer (display).
+ * No environment detection logic - delegates to existing utilities.
+ *
+ * @implements {ISpinner}
+ */
+export class OraSpinner implements ISpinner {
+  private renderer: SpinnerRenderer;
+  private isStarted = false;
+  private prefix?: string;
+  private currentMessage = '';
+
+  constructor() {
+    this.renderer = new SpinnerRenderer();
+  }
+
+  /**
+   * Set the logger prefix for consistent formatting across all DevLogr APIs
+   */
+  setPrefix(prefix: string): void {
+    this.prefix = prefix;
+  }
+
+  start(text: string): void {
+    this.stop(); // Ensure clean state
+    this.currentMessage = text;
+
+    if (SpinnerRenderer.shouldAnimate()) {
+      // TTY environment - start animation with proper formatting
+      this.renderer.startAnimation(text, 'task', this.prefix);
+    } else {
+      // CI environment - static output using MessageFormatter
+      const formatted = MessageFormatter.formatSpinnerOutput(text, 'task', this.prefix, 'running');
+      this.renderer.renderStatic(formatted.fullText);
+    }
+
+    this.isStarted = true;
+  }
+
+  stop(): void {
+    if (this.renderer.isCurrentlyAnimating()) {
+      this.renderer.stopAnimation();
+    }
+    this.isStarted = false;
+  }
+
+  succeed(text?: string): void {
+    this.stop();
+    if (text) {
+      const formatted = MessageFormatter.formatSpinnerOutput(
+        text,
+        'success',
+        this.prefix,
+        'success'
+      );
+      this.renderer.renderStatic(formatted.fullText);
+    }
+    this.isStarted = false;
+  }
+
+  fail(text?: string): void {
+    this.stop();
+    if (text) {
+      const formatted = MessageFormatter.formatSpinnerOutput(text, 'error', this.prefix, 'error');
+      this.renderer.renderStatic(formatted.fullText);
+    }
+    this.isStarted = false;
+  }
+
+  warn(text?: string): void {
+    this.stop();
+    if (text) {
+      const formatted = MessageFormatter.formatSpinnerOutput(text, 'warn', this.prefix, 'warning');
+      this.renderer.renderStatic(formatted.fullText);
+    }
+    this.isStarted = false;
+  }
+
+  info(text?: string): void {
+    this.stop();
+    if (text) {
+      const formatted = MessageFormatter.formatSpinnerOutput(text, 'info', this.prefix, 'info');
+      this.renderer.renderStatic(formatted.fullText);
+    }
+    this.isStarted = false;
+  }
+
+  updateText(text: string): void {
+    this.currentMessage = text;
+    if (this.renderer.isCurrentlyAnimating()) {
+      // Update the animation with new message
+      this.renderer.updateMessage(text);
+    }
+  }
+
+  isActive(): boolean {
+    return this.isStarted;
+  }
+}

--- a/src/adapters/spinner-renderer.ts
+++ b/src/adapters/spinner-renderer.ts
@@ -1,0 +1,114 @@
+import { TerminalUtils } from '../utils/terminal';
+import { MessageFormatter } from '../formatters';
+
+/**
+ * SpinnerRenderer handles the visual rendering of spinners.
+ * Follows Single Responsibility Principle - only concerned with display logic.
+ * Environment detection and formatting delegated to existing systems.
+ */
+export class SpinnerRenderer {
+  private animationFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
+  private frameIndex = 0;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private isAnimating = false;
+  private currentMessage = '';
+  private currentLevel = '';
+  private currentPrefix?: string;
+
+  /**
+   * Render a static spinner message (for CI environments or completion messages).
+   * Uses MessageFormatter for consistent output.
+   */
+  renderStatic(fullText: string): void {
+    console.log(fullText);
+  }
+
+  /**
+   * Start animated spinner rendering (for TTY environments).
+   * Uses MessageFormatter to generate properly colored and spaced output for each frame.
+   */
+  startAnimation(message: string, level: string, prefix?: string): void {
+    this.stopAnimation(); // Ensure clean state
+
+    this.currentMessage = message;
+    this.currentLevel = level;
+    this.currentPrefix = prefix;
+    this.frameIndex = 0;
+    this.isAnimating = true;
+
+    // Initial render
+    this.renderFrame();
+
+    // Start animation timer
+    this.timer = setInterval(() => {
+      this.frameIndex = (this.frameIndex + 1) % this.animationFrames.length;
+      this.renderFrame();
+    }, 80); // 80ms for smooth animation
+  }
+
+  /**
+   * Stop animation and clear the spinner line.
+   */
+  stopAnimation(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+
+    if (this.isAnimating && process.stdout.isTTY) {
+      // Clear the current line
+      process.stdout.write('\r\x1b[K');
+    }
+
+    this.isAnimating = false;
+  }
+
+  /**
+   * Update the message text of a running animation.
+   */
+  updateMessage(newMessage: string): void {
+    if (this.isAnimating) {
+      this.currentMessage = newMessage;
+      this.renderFrame();
+    }
+  }
+
+  /**
+   * Check if currently animating.
+   */
+  isCurrentlyAnimating(): boolean {
+    return this.isAnimating;
+  }
+
+  /**
+   * Render a single animation frame.
+   * Uses MessageFormatter to maintain consistent formatting and coloring.
+   */
+  private renderFrame(): void {
+    if (!this.isAnimating || !process.stdout.isTTY) {
+      return;
+    }
+
+    // Get current animation frame
+    const currentIcon = this.animationFrames[this.frameIndex];
+
+    // Use MessageFormatter to generate properly formatted output with current animation frame
+    const animatedLine = MessageFormatter.formatSpinnerOutputWithCustomIcon(
+      this.currentMessage,
+      this.currentLevel,
+      this.currentPrefix,
+      currentIcon
+    );
+
+    // Clear line and write new content - \r moves to start, \x1b[K clears to end
+    process.stdout.write(`\r\x1b[K${animatedLine}`);
+  }
+
+  /**
+   * Determine if we should use animation or static rendering.
+   * Delegates to existing utilities (Dependency Inversion Principle).
+   */
+  static shouldAnimate(): boolean {
+    return TerminalUtils.supportsColor() && !!process.stdout.isTTY;
+  }
+}

--- a/src/adapters/spinner-renderer.ts
+++ b/src/adapters/spinner-renderer.ts
@@ -2,9 +2,7 @@ import { TerminalUtils } from '../utils/terminal';
 import { MessageFormatter } from '../formatters';
 
 /**
- * SpinnerRenderer handles the visual rendering of spinners.
- * Follows Single Responsibility Principle - only concerned with display logic.
- * Environment detection and formatting delegated to existing systems.
+ * Handles visual rendering of animated spinners.
  */
 export class SpinnerRenderer {
   private animationFrames = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
@@ -15,20 +13,12 @@ export class SpinnerRenderer {
   private currentLevel = '';
   private currentPrefix?: string;
 
-  /**
-   * Render a static spinner message (for CI environments or completion messages).
-   * Uses MessageFormatter for consistent output.
-   */
   renderStatic(fullText: string): void {
     console.log(fullText);
   }
 
-  /**
-   * Start animated spinner rendering (for TTY environments).
-   * Uses MessageFormatter to generate properly colored and spaced output for each frame.
-   */
   startAnimation(message: string, level: string, prefix?: string): void {
-    this.stopAnimation(); // Ensure clean state
+    this.stopAnimation();
 
     this.currentMessage = message;
     this.currentLevel = level;
@@ -36,19 +26,14 @@ export class SpinnerRenderer {
     this.frameIndex = 0;
     this.isAnimating = true;
 
-    // Initial render
     this.renderFrame();
 
-    // Start animation timer
     this.timer = setInterval(() => {
       this.frameIndex = (this.frameIndex + 1) % this.animationFrames.length;
       this.renderFrame();
     }, 80); // 80ms for smooth animation
   }
 
-  /**
-   * Stop animation and clear the spinner line.
-   */
   stopAnimation(): void {
     if (this.timer) {
       clearInterval(this.timer);
@@ -56,16 +41,12 @@ export class SpinnerRenderer {
     }
 
     if (this.isAnimating && process.stdout.isTTY) {
-      // Clear the current line
       process.stdout.write('\r\x1b[K');
     }
 
     this.isAnimating = false;
   }
 
-  /**
-   * Update the message text of a running animation.
-   */
   updateMessage(newMessage: string): void {
     if (this.isAnimating) {
       this.currentMessage = newMessage;
@@ -73,26 +54,17 @@ export class SpinnerRenderer {
     }
   }
 
-  /**
-   * Check if currently animating.
-   */
   isCurrentlyAnimating(): boolean {
     return this.isAnimating;
   }
 
-  /**
-   * Render a single animation frame.
-   * Uses MessageFormatter to maintain consistent formatting and coloring.
-   */
   private renderFrame(): void {
     if (!this.isAnimating || !process.stdout.isTTY) {
       return;
     }
 
-    // Get current animation frame
     const currentIcon = this.animationFrames[this.frameIndex];
 
-    // Use MessageFormatter to generate properly formatted output with current animation frame
     const animatedLine = MessageFormatter.formatSpinnerOutputWithCustomIcon(
       this.currentMessage,
       this.currentLevel,
@@ -100,14 +72,9 @@ export class SpinnerRenderer {
       currentIcon
     );
 
-    // Clear line and write new content - \r moves to start, \x1b[K clears to end
     process.stdout.write(`\r\x1b[K${animatedLine}`);
   }
 
-  /**
-   * Determine if we should use animation or static rendering.
-   * Delegates to existing utilities (Dependency Inversion Principle).
-   */
   static shouldAnimate(): boolean {
     return TerminalUtils.supportsColor() && !!process.stdout.isTTY;
   }

--- a/src/adapters/spinner-renderer.ts
+++ b/src/adapters/spinner-renderer.ts
@@ -1,5 +1,6 @@
 import { TerminalUtils } from '../utils/terminal';
 import { MessageFormatter } from '../formatters';
+import { LogConfiguration } from '../config';
 
 /**
  * Handles visual rendering of animated spinners.
@@ -76,6 +77,7 @@ export class SpinnerRenderer {
   }
 
   static shouldAnimate(): boolean {
-    return TerminalUtils.supportsColor() && !!process.stdout.isTTY;
+    const config = LogConfiguration.getConfig();
+    return config.showIcons && TerminalUtils.supportsColor() && !!process.stdout.isTTY;
   }
 }

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,7 @@ export class LogConfiguration {
     }
 
     if (timestampValue === '1') {
-    return { show: true, format: TimestampFormat.TIME };
+      return { show: true, format: TimestampFormat.TIME };
     }
 
     // Default to disabled (false) for any other value or no value
@@ -128,7 +128,7 @@ export class LogConfiguration {
 
     // Environment variable takes precedence
     if (showPrefixValue !== undefined) {
-    return showPrefixValue === 'true' || showPrefixValue === '1';
+      return showPrefixValue === 'true' || showPrefixValue === '1';
     }
 
     // Fall back to CI detection

--- a/src/config.ts
+++ b/src/config.ts
@@ -16,7 +16,7 @@ export class LogConfiguration {
   private static readonly ENV_SHOW_TIMESTAMP = 'DEVLOGR_SHOW_TIMESTAMP';
   private static readonly ENV_SHOW_PREFIX = 'DEVLOGR_SHOW_PREFIX';
   private static readonly ENV_SHOW_EMOJI = 'DEVLOGR_SHOW_EMOJI';
-  private static readonly ENV_NO_ICONS = 'DEVLOGR_NO_ICONS';
+  private static readonly ENV_SHOW_ICONS = 'DEVLOGR_SHOW_ICONS';
   private static readonly ENV_DISABLE_CI_DETECTION = 'DEVLOGR_DISABLE_CI_DETECTION';
 
   /**
@@ -156,11 +156,11 @@ export class LogConfiguration {
    * Checks if icons should be shown in output, considering both environment variables and CI detection
    */
   private static shouldShowIcons(ciIcons: boolean): boolean {
-    const showIconsValue = process.env[this.ENV_NO_ICONS];
+    const showIconsValue = process.env[this.ENV_SHOW_ICONS];
 
     // Environment variable takes precedence
     if (showIconsValue !== undefined) {
-      return !(showIconsValue === 'true' || showIconsValue === '1');
+      return showIconsValue === 'true' || showIconsValue === '1';
     }
 
     // Fall back to CI detection

--- a/src/config.ts
+++ b/src/config.ts
@@ -100,7 +100,7 @@ export class LogConfiguration {
     }
 
     if (timestampValue === '1') {
-      return { show: true, format: TimestampFormat.TIME };
+    return { show: true, format: TimestampFormat.TIME };
     }
 
     // Default to disabled (false) for any other value or no value
@@ -128,7 +128,7 @@ export class LogConfiguration {
 
     // Environment variable takes precedence
     if (showPrefixValue !== undefined) {
-      return showPrefixValue === 'true' || showPrefixValue === '1';
+    return showPrefixValue === 'true' || showPrefixValue === '1';
     }
 
     // Fall back to CI detection

--- a/src/config.ts
+++ b/src/config.ts
@@ -15,6 +15,7 @@ export class LogConfiguration {
   private static readonly ENV_DEVLOGR_NO_COLOR = 'DEVLOGR_NO_COLOR';
   private static readonly ENV_SHOW_TIMESTAMP = 'DEVLOGR_SHOW_TIMESTAMP';
   private static readonly ENV_SHOW_PREFIX = 'DEVLOGR_SHOW_PREFIX';
+  private static readonly ENV_SHOW_EMOJI = 'DEVLOGR_SHOW_EMOJI';
   private static readonly ENV_NO_ICONS = 'DEVLOGR_NO_ICONS';
   private static readonly ENV_DISABLE_CI_DETECTION = 'DEVLOGR_DISABLE_CI_DETECTION';
 
@@ -35,6 +36,7 @@ export class LogConfiguration {
       useColors: this.shouldUseColors(),
       supportsUnicode: this.supportsUnicode(),
       supportsEmoji: this.supportsEmoji(),
+      showEmojis: this.shouldShowEmojis(ciConfig.showEmojis),
       showTimestamp: this.shouldShowTimestamp(timestampConfig.show, ciConfig.showTimestamp),
       timestampFormat: timestampConfig.format,
       showPrefix: this.shouldShowPrefix(ciConfig.showPrefix),
@@ -133,6 +135,21 @@ export class LogConfiguration {
 
     // Fall back to CI detection
     return ciPrefix;
+  }
+
+  /**
+   * Checks if emojis should be shown in output, considering both environment variables and CI detection
+   */
+  private static shouldShowEmojis(ciEmojis: boolean): boolean {
+    const showEmojisValue = process.env[this.ENV_SHOW_EMOJI];
+
+    // Environment variable takes precedence
+    if (showEmojisValue !== undefined) {
+      return showEmojisValue === 'true' || showEmojisValue === '1';
+    }
+
+    // Fall back to CI detection and emoji support
+    return ciEmojis && this.supportsEmoji();
   }
 
   /**

--- a/src/config.ts
+++ b/src/config.ts
@@ -139,11 +139,11 @@ export class LogConfiguration {
    * Checks if icons should be shown in output, considering both environment variables and CI detection
    */
   private static shouldShowIcons(ciIcons: boolean): boolean {
-    const noIconsValue = process.env[this.ENV_NO_ICONS];
+    const showIconsValue = process.env[this.ENV_NO_ICONS];
 
     // Environment variable takes precedence
-    if (noIconsValue !== undefined) {
-      return !(noIconsValue === 'true' || noIconsValue === '1');
+    if (showIconsValue !== undefined) {
+      return !(showIconsValue === 'true' || showIconsValue === '1');
     }
 
     // Fall back to CI detection

--- a/src/config.ts
+++ b/src/config.ts
@@ -141,6 +141,11 @@ export class LogConfiguration {
    * Checks if emojis should be shown in output, considering both environment variables and CI detection
    */
   private static shouldShowEmojis(ciEmojis: boolean): boolean {
+    // Check global standards first (NO_COLOR and NO_EMOJI should disable emojis)
+    if (process.env.NO_COLOR !== undefined || process.env.NO_EMOJI !== undefined) {
+      return false;
+    }
+
     const showEmojisValue = process.env[this.ENV_SHOW_EMOJI];
 
     // Environment variable takes precedence

--- a/src/devlogr-renderer.ts
+++ b/src/devlogr-renderer.ts
@@ -187,7 +187,11 @@ export class DevLogrRenderer implements ListrRenderer {
     let symbol: string;
     let title = task.title;
 
-    if (task.isStarted() && !task.isCompleted() && !task.hasFailed() && !done) {
+    const config = LogConfiguration.getConfig();
+
+    if (!config.showIcons) {
+      symbol = '';
+    } else if (task.isStarted() && !task.isCompleted() && !task.hasFailed() && !done) {
       // Loading animation - blue color
       const spinnerSymbol = this.spinner ? this.spinner.fetch() : '⠋';
       symbol = ChalkUtils.getChalkInstance(this.options.useColors).blue(spinnerSymbol);
@@ -230,7 +234,11 @@ export class DevLogrRenderer implements ListrRenderer {
       let symbol: string;
       let title = task.title;
 
-      if (task.isStarted() && !task.isCompleted() && !task.hasFailed() && !done) {
+      const config = LogConfiguration.getConfig();
+
+      if (!config.showIcons) {
+        symbol = '';
+      } else if (task.isStarted() && !task.isCompleted() && !task.hasFailed() && !done) {
         // Loading animation - blue color
         const spinnerSymbol = this.spinner ? this.spinner.fetch() : '⠋';
         symbol = ChalkUtils.getChalkInstance(this.options.useColors).blue(spinnerSymbol);
@@ -260,7 +268,9 @@ export class DevLogrRenderer implements ListrRenderer {
           .trim()
           .split('\n')
           .forEach(line => {
-            const outputSymbol = ChalkUtils.getChalkInstance(this.options.useColors).cyan('›');
+            const outputSymbol = config.showIcons
+              ? ChalkUtils.getChalkInstance(this.options.useColors).cyan('›')
+              : '';
             output.push(this.formatListrMessage(line, outputSymbol, level + 1));
           });
       }

--- a/src/devlogr-renderer.ts
+++ b/src/devlogr-renderer.ts
@@ -11,7 +11,6 @@ import { MessageFormatter } from './formatters';
 import { ThemeProvider } from './themes';
 import { PrefixTracker } from './tracker';
 import { TimestampFormat } from './types';
-import { LogConfiguration } from './config';
 import { ChalkUtils } from './utils/chalk';
 
 export interface DevLogrRendererOptions {
@@ -51,7 +50,7 @@ export class DevLogrRenderer implements ListrRenderer {
       supportsUnicode: options.supportsUnicode ?? true,
       prefix: options.prefix ?? 'listr2',
       lazy: options.lazy ?? false,
-      taskLevel: options.taskLevel ?? 'plain',
+      taskLevel: options.taskLevel ?? 'task',
     };
   }
 
@@ -161,7 +160,6 @@ export class DevLogrRenderer implements ListrRenderer {
   }
 
   private formatTaskMessage(message: string, symbol: string, level = 0): string {
-    const config = LogConfiguration.getConfig();
     const theme = ThemeProvider.getTheme(
       this.options.taskLevel,
       undefined,
@@ -169,12 +167,13 @@ export class DevLogrRenderer implements ListrRenderer {
     );
     const maxPrefixLength = PrefixTracker.getMaxLength();
 
-    // Use renderer options for prefix/timestamp settings, falling back to config
-    const showPrefix = this.options.prefix !== undefined && config.showPrefix;
+    // Use renderer options for prefix/timestamp settings
+    // If prefix is provided in options, we should show it (respecting the Logger's intent)
+    const showPrefix = this.options.prefix !== undefined;
     const showTimestamp = this.options.showTimestamp;
 
-    // Special handling for plain level when prefix is disabled
-    if (this.options.taskLevel === 'plain' && !showPrefix) {
+    // Special handling for task level when prefix is disabled
+    if (this.options.taskLevel === 'task' && !showPrefix) {
       const indentation = '  '.repeat(level);
       return `${indentation}${symbol} ${message}`;
     }
@@ -190,7 +189,7 @@ export class DevLogrRenderer implements ListrRenderer {
       useColors: this.options.useColors,
       timestampFormat: this.options.timestampFormat,
       stripEmojis: !this.options.supportsUnicode,
-      includeLevel: showPrefix,
+      includeLevel: showPrefix, // Show level label when prefix is shown
       includePrefix: showPrefix,
     });
 

--- a/src/devlogr-renderer.ts
+++ b/src/devlogr-renderer.ts
@@ -94,11 +94,7 @@ export class DevLogrRenderer implements ListrRenderer {
     if (allTasksComplete && this.spinner) {
       this.isStopped = true;
       this.spinner.stop();
-
-      if (this.updater && process.stdout.isTTY) {
-        this.updater('');
-        this.updater.done();
-      }
+      // Don't clear updater here - let end() handle final output and cleanup
       return;
     }
 

--- a/src/devlogr-renderer.ts
+++ b/src/devlogr-renderer.ts
@@ -318,7 +318,7 @@ export class DevLogrRenderer implements ListrRenderer {
     // Strip emojis from task data if user preference is disabled
     const processedTitle = EmojiUtils.shouldShowEmojis()
       ? task.title
-      : EmojiUtils.format(task.title);
+      : EmojiUtils.format(task.title || '');
     const processedOutput = task.output
       ? EmojiUtils.shouldShowEmojis()
         ? task.output

--- a/src/devlogr-renderer.ts
+++ b/src/devlogr-renderer.ts
@@ -219,21 +219,16 @@ export class DevLogrRenderer implements ListrRenderer {
   }
 
   private formatListrMessage(message: string, symbol: string, level = 0): string {
+    // Handle indentation for nested tasks - add spaces before the symbol only
+    const indentedSymbol = level > 0 ? `${'  '.repeat(level)}${symbol}` : symbol;
+
     // Use centralized formatting - MessageFormatter handles proper component ordering
-    // Format: [Timestamp] [Level] [Prefix] [Symbol] [Message]
-    const formattedMessage = MessageFormatter.formatWithPrefix(
+    // Format: [Timestamp] [Level] [Prefix] [IndentedSymbol] [Message]
+    return MessageFormatter.formatWithPrefix(
       message,
-      symbol,
+      indentedSymbol,
       this.options.level,
       this.options.prefix
     );
-
-    // Handle indentation for nested tasks by prepending spaces
-    if (level > 0) {
-      const indentation = '  '.repeat(level);
-      return `${indentation}${formattedMessage}`;
-    }
-
-    return formattedMessage;
   }
 }

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -37,7 +37,7 @@ export class MessageFormatter {
     const config = LogConfiguration.getConfig();
     const theme = ThemeProvider.getTheme(level, undefined, config.supportsUnicode);
     const maxPrefixLength = PrefixTracker.getMaxLength();
-    const shouldShowEmojis = EmojiUtils.supportsEmoji();
+    const shouldShowEmojis = EmojiUtils.shouldShowEmojis();
 
     const customTheme: LogTheme = {
       symbol: messagePrefix,
@@ -91,7 +91,7 @@ export class MessageFormatter {
     messagePart: string; // "message text"
   } {
     const config = LogConfiguration.getConfig();
-    const shouldShowEmojis = EmojiUtils.supportsEmoji();
+    const shouldShowEmojis = EmojiUtils.shouldShowEmojis();
 
     // Map icon types to appropriate themes and symbols
     const iconMapping = {
@@ -145,7 +145,7 @@ export class MessageFormatter {
   ): string {
     const config = LogConfiguration.getConfig();
     const theme = ThemeProvider.getTheme(level, undefined, config.supportsUnicode);
-    const shouldShowEmojis = EmojiUtils.supportsEmoji();
+    const shouldShowEmojis = EmojiUtils.shouldShowEmojis();
 
     // Use the custom icon if provided, otherwise fall back to theme default
     const finalIcon = customIcon || theme.symbol;

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -3,7 +3,7 @@ import { StringUtils, EmojiUtils } from './utils';
 import { ChalkUtils } from './utils/chalk';
 
 // ============================================================================
-// MESSAGE FORMATTING - UNIFIED FORMATTER
+// MESSAGE FORMATTING - SIMPLIFIED UNIFIED FORMATTER
 // ============================================================================
 
 interface FormatOptions {
@@ -21,10 +21,14 @@ interface FormatOptions {
   includePrefix?: boolean;
 }
 
+/**
+ * Simplified MessageFormatter with consolidated formatting logic.
+ * Follows DRY principle by using a single format method for all scenarios.
+ */
 export class MessageFormatter {
   /**
-   * Universal formatter - handles all formatting scenarios
-   * Single method for consistent message formatting across all log types
+   * Universal formatter - handles all formatting scenarios with a single method.
+   * This eliminates the need for multiple specialized formatting methods.
    */
   static format(options: FormatOptions): string {
     const {
@@ -46,8 +50,7 @@ export class MessageFormatter {
 
     // 1. Timestamp
     if (showTimestamp) {
-      const timestamp = this.formatTimestamp(timestampFormat, useColors);
-      parts.push(timestamp);
+      parts.push(this.formatTimestamp(timestampFormat, useColors));
     }
 
     // 2. Symbol and Level
@@ -58,21 +61,19 @@ export class MessageFormatter {
 
     // 3. Prefix with proper spacing
     if (includePrefix && prefix) {
-      const formatted = this.formatPrefix(prefix, maxPrefixLength, useColors);
-      parts.push(formatted);
+      parts.push(this.formatPrefix(prefix, maxPrefixLength, useColors));
     }
 
     // 4. Message with styling
     if (message) {
-      const formatted = this.formatMessage(level, theme, message, args, useColors, stripEmojis);
-      parts.push(formatted);
+      parts.push(this.formatMessage(level, theme, message, args, useColors, stripEmojis));
     }
 
     return parts.join(' ').trim();
   }
 
   // ============================================================================
-  // PRIVATE HELPERS - EXTRACTED FOR CLARITY
+  // PRIVATE HELPERS - CONSOLIDATED AND SIMPLIFIED
   // ============================================================================
 
   private static formatTimestamp(timestampFormat: TimestampFormat, useColors: boolean): string {
@@ -150,26 +151,35 @@ export class MessageFormatter {
 
     const chalkInstance = ChalkUtils.getChalkInstance(useColors);
 
-    // Bold levels for important messages
-    if (['error', 'success'].includes(level)) {
+    // Use a mapping approach for cleaner code
+    const styleRules = {
+      bold: ['error', 'success'],
+      colored: ['warn', 'title', 'task', 'plain'],
+      dimmed: ['trace']
+    };
+
+    if (styleRules.bold.includes(level)) {
       return chalkInstance.bold(colorFn(message));
     }
 
-    // Colored levels for contextual messages
-    if (['warn', 'title', 'task', 'plain'].includes(level)) {
+    if (styleRules.colored.includes(level)) {
       return colorFn(message);
     }
 
-    // Dimmed for debug/trace
-    if (level === 'trace') {
+    if (styleRules.dimmed.includes(level)) {
       return chalkInstance.dim(message);
     }
 
     return message;
   }
 
+  // ============================================================================
+  // BACKWARD COMPATIBILITY METHODS - SIMPLIFIED WRAPPERS
+  // ============================================================================
+
   /**
    * Format basic prefix with timestamp and spacing
+   * @deprecated Use format() method directly for better flexibility
    */
   static formatBasicPrefix(
     prefix: string,
@@ -188,6 +198,7 @@ export class MessageFormatter {
 
   /**
    * Format message with theme and emoji handling
+   * @deprecated Use format() method directly for better flexibility
    */
   static formatSimpleMessage(
     level: string,
@@ -212,6 +223,7 @@ export class MessageFormatter {
 
   /**
    * Format spinner prefix with level symbol and timestamp
+   * @deprecated Use format() method directly for better flexibility
    */
   static formatSpinnerPrefixWithLevel(
     level: string,
@@ -233,11 +245,13 @@ export class MessageFormatter {
       useColors,
       timestampFormat,
       includeLevel: true,
+      includePrefix: true,
     });
   }
 
   /**
    * Format complete log message with all elements
+   * @deprecated Use format() method directly for better flexibility
    */
   static formatCompleteLogMessage(
     level: string,
@@ -261,6 +275,8 @@ export class MessageFormatter {
       useColors,
       timestampFormat,
       stripEmojis,
+      includeLevel: true,
+      includePrefix: true,
     });
   }
 }

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -155,7 +155,7 @@ export class MessageFormatter {
     const styleRules = {
       bold: ['error', 'success'],
       colored: ['warn', 'title', 'task', 'plain'],
-      dimmed: ['trace']
+      dimmed: ['trace'],
     };
 
     if (styleRules.bold.includes(level)) {

--- a/src/formatters.ts
+++ b/src/formatters.ts
@@ -95,7 +95,7 @@ export class MessageFormatter {
 
     // Map icon types to appropriate themes and symbols
     const iconMapping = {
-      running: { level: 'task', symbol: shouldShowEmojis ? '⠋' : '...' },
+      running: { level: 'task', symbol: config.showIcons ? (shouldShowEmojis ? '⠋' : '...') : '' },
       success: { level: 'success', symbol: undefined }, // Use theme default
       error: { level: 'error', symbol: undefined },
       warning: { level: 'warn', symbol: undefined },

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -213,14 +213,7 @@ class TaskRunner {
       level: 'task',
     });
 
-    try {
-      const result = await listr.run(context);
-      this.logger.outputDevLogrFormattedTask(`${title} completed successfully`, '✔');
-      return result;
-    } catch (error) {
-      this.logger.outputDevLogrFormattedTask(`${title} failed`, '✖');
-      throw error;
-    }
+    return await listr.run(context);
   }
 
   createTaskList<T = Record<string, unknown>>(

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -486,6 +486,10 @@ export class Logger {
         supportsUnicode: this.config.supportsUnicode,
         ...options?.rendererOptions,
       },
+      // Force our renderer to be used even in non-TTY environments (CI)
+      fallbackRenderer: DevLogrRenderer,
+      fallbackRendererCondition: false, // Never fallback to a different renderer
+      silentRendererCondition: false, // Never use silent renderer
     });
 
     try {
@@ -523,6 +527,10 @@ export class Logger {
         supportsUnicode: this.config.supportsUnicode,
         taskLevel: options?.taskLevel,
       },
+      // Force our renderer to be used even in non-TTY environments (CI)
+      fallbackRenderer: DevLogrRenderer,
+      fallbackRendererCondition: false, // Never fallback to a different renderer
+      silentRendererCondition: false, // Never use silent renderer
     });
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -104,8 +104,8 @@ class JsonLogger {
   }
 
   private buildLogData(level: LogLevel, message: string, args: unknown[]): Record<string, unknown> {
-    const shouldStripEmojis = true; // Always strip emojis in JSON mode
-    const finalMessage = shouldStripEmojis ? EmojiUtils.forceStripEmojis(message) : message;
+    const shouldShowEmojis = false; // Never show emojis in JSON mode for consistency
+    const finalMessage = shouldShowEmojis ? message : EmojiUtils.forceStripEmojis(message);
 
     const logData: Record<string, unknown> = {
       level,
@@ -117,10 +117,10 @@ class JsonLogger {
     // Add arguments to log data
     args.forEach((arg, index) => {
       if (this.isPlainObject(arg) && !this.hasCircularReferences(arg)) {
-        this.mergeObjectArg(logData, arg as Record<string, unknown>, index, shouldStripEmojis);
+        this.mergeObjectArg(logData, arg as Record<string, unknown>, index, shouldShowEmojis);
       } else {
         let processedArg = arg;
-        if (shouldStripEmojis && typeof arg === 'string') {
+        if (!shouldShowEmojis && typeof arg === 'string') {
           processedArg = EmojiUtils.forceStripEmojis(arg);
         }
         this.addSimpleArg(logData, processedArg, index);
@@ -147,12 +147,12 @@ class JsonLogger {
     logData: Record<string, unknown>,
     arg: Record<string, unknown>,
     index: number,
-    shouldStripEmojis: boolean
+    shouldShowEmojis: boolean
   ): void {
     Object.keys(arg).forEach(key => {
       const safeKey = key in logData ? `arg${index}_${key}` : key;
       let value = arg[key];
-      if (shouldStripEmojis && typeof value === 'string') {
+      if (!shouldShowEmojis && typeof value === 'string') {
         value = EmojiUtils.forceStripEmojis(value);
       }
       logData[safeKey] = value;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -49,22 +49,7 @@ class SpinnerManager {
 
   complete(type: 'success' | 'error' | 'warning' | 'info', text?: string): void {
     if (!this.singleSpinnerListr) {
-      // When no spinner is active, fallback to the appropriate logger method
-      const completionText = text || this.getDefaultCompletionText(type);
-      switch (type) {
-        case 'success':
-          this.logger.success(completionText);
-          break;
-        case 'error':
-          this.logger.error(completionText);
-          break;
-        case 'warning':
-          this.logger.warning(completionText);
-          break;
-        case 'info':
-          this.logger.info(completionText);
-          break;
-      }
+      // No active spinner, nothing to complete
       return;
     }
 
@@ -362,8 +347,8 @@ export class Logger {
 
   // Simplified completion methods using delegation
   completeSpinner(type: 'success' | 'error' | 'warning' | 'info', text?: string): void {
-    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
-      // Fallback to regular logging using the correct method names
+    if (this.config.useJson) {
+      // Only handle JSON mode fallback here
       const completionText = text || this.getDefaultCompletionText(type);
       switch (type) {
         case 'success':
@@ -381,7 +366,7 @@ export class Logger {
       }
       return;
     }
-    // Delegate to spinner manager which handles its own fallback logic
+    // Always delegate to spinner manager - it handles CI/TTY differences properly
     this.spinnerManager.complete(type, text);
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -381,7 +381,6 @@ export class Logger {
       }
       return;
     }
-    // Delegate to spinner manager which handles its own fallback logic
     this.spinnerManager.complete(type, text);
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -9,667 +9,99 @@ import { DevLogrRenderer } from './devlogr-renderer';
 import { ChalkUtils } from './utils/chalk';
 
 // ============================================================================
-// LOGGER IMPLEMENTATION - CORE FUNCTIONALITY
+// SPINNER MANAGER - EXTRACTED FROM LOGGER FOR SINGLE RESPONSIBILITY
 // ============================================================================
 
-/**
- * Main DevLogr Logger class providing structured logging with visual enhancements.
- *
- * The Logger class is the heart of DevLogr, offering:
- * - Multiple log levels (error, warning, info, debug, trace, success)
- * - Animated spinners with automatic fallbacks
- * - Task management integration with listr2
- * - JSON output mode for machine parsing
- * - Terminal-aware formatting with color and emoji support
- * - Zero-configuration setup with environment variable overrides
- *
- * @example Basic Usage
- * ```typescript
- * import { createLogger } from '@neofork/devlogr';
- *
- * const log = createLogger('my-app');
- *
- * log.info('Application starting...');
- * log.success('Setup complete!');
- * log.error('Something went wrong', error);
- * ```
- *
- * @example Spinner Usage
- * ```typescript
- * const log = createLogger('deploy');
- *
- * log.startSpinner('Deploying application...');
- * // ... do work ...
- * log.succeedSpinner('Deployment successful!');
- * ```
- *
- * @example Task Management
- * ```typescript
- * const log = createLogger('build');
- *
- * await log.runTasks('Build Process', [
- *   { title: 'Compile TypeScript', task: () => compileTS() },
- *   { title: 'Bundle Assets', task: () => bundleAssets() },
- *   { title: 'Generate Documentation', task: () => generateDocs() }
- * ]);
- * ```
- */
-export class Logger {
-  private readonly prefix: string;
-  private readonly config: LogConfig;
-  private static globalLevel?: LogLevel;
-
-  // Single spinner state - wraps around multi-spinner API
+class SpinnerManager {
   private singleSpinnerListr: Listr | null = null;
-  private singleSpinnerTask: { resolver?: () => void; rejecter?: (error: Error) => void } | null =
-    null;
+  private singleSpinnerTask: { resolver?: () => void; rejecter?: (error: Error) => void } | null = null;
 
-  constructor(prefix: string) {
-    this.prefix = prefix;
-    this.config = LogConfiguration.getConfig();
-    PrefixTracker.register(prefix);
+  constructor(private readonly logger: Logger) {}
+
+  start(text?: string, options?: Omit<SpinnerOptions, 'text'>): void {
+    const spinnerText = text || 'Loading...';
+    
+    if (this.singleSpinnerListr) {
+      this.stop();
+    }
+
+    this.singleSpinnerListr = SpinnerUtils.start('single', this.logger.buildSpinnerOptions(spinnerText, 'task', options));
   }
 
-  // ============================================================================
-  // STATIC LEVEL MANAGEMENT
-  // ============================================================================
-
-  /**
-   * Set the global log level for all Logger instances.
-   * Overrides environment variable configuration.
-   *
-   * @param level - The minimum log level to display
-   */
-  static setLevel(level: LogLevel): void {
-    Logger.globalLevel = level;
+  updateText(text: string): void {
+    if (this.singleSpinnerListr) {
+      SpinnerUtils.updateText('single', text);
+    }
   }
 
-  /**
-   * Reset the global log level to use environment-based configuration.
-   */
-  static resetLevel(): void {
-    Logger.globalLevel = undefined;
+  stop(): void {
+    if (this.singleSpinnerListr) {
+      SpinnerUtils.stop('single');
+      this.singleSpinnerListr = null;
+      this.singleSpinnerTask = null;
+    }
   }
 
-  // ============================================================================
-  // CORE LOGGING METHODS
-  // ============================================================================
-
-  /**
-   * Log an informational message.
-   *
-   * @param message - The main message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  info(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.INFO, 'info', message, ...args);
-  }
-
-  /**
-   * Log an error message with optional error object.
-   *
-   * @param message - The error message to log
-   * @param error - Optional error object or additional data
-   * @param args - Additional arguments to include in the log output
-   */
-  error(message: string, error?: unknown, ...args: unknown[]): void {
-    const allArgs = error ? [error, ...args] : args;
-    this.log(LogLevel.ERROR, 'error', message, ...allArgs);
-  }
-
-  /**
-   * Log a warning message.
-   *
-   * @param message - The warning message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  warning(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.WARNING, 'warn', message, ...args);
-  }
-
-  /**
-   * Alias for warning() method.
-   *
-   * @param message - The warning message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  warn(message: string, ...args: unknown[]): void {
-    this.warning(message, ...args);
-  }
-
-  /**
-   * Log a debug message (only shown when debug level is enabled).
-   *
-   * @param message - The debug message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  debug(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.DEBUG, 'debug', message, ...args);
-  }
-
-  /**
-   * Log a trace message (only shown when trace level is enabled).
-   *
-   * @param message - The trace message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  trace(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.TRACE, 'trace', message, ...args);
-  }
-
-  /**
-   * Log a success message with positive visual styling.
-   *
-   * @param message - The success message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  success(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.INFO, 'success', message, ...args);
-  }
-
-  /**
-   * Log a title message with prominent visual styling.
-   *
-   * @param message - The title message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  title(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.INFO, 'title', message, ...args);
-  }
-
-  /**
-   * Log a task message indicating work in progress.
-   *
-   * @param message - The task message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  task(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.INFO, 'task', message, ...args);
-  }
-
-  /**
-   * Log a plain message without any visual styling or symbols.
-   *
-   * @param message - The plain message to log
-   * @param args - Additional arguments to include in the log output
-   */
-  plain(message: string, ...args: unknown[]): void {
-    this.log(LogLevel.INFO, 'plain', message, ...args);
-  }
-
-  // ============================================================================
-  // SPINNER MANAGEMENT METHODS
-  // ============================================================================
-
-  /**
-   * Start an animated spinner with optional text and styling options.
-   *
-   * Spinners provide visual feedback for long-running operations. They automatically
-   * fall back to simple task messages in JSON mode or when the terminal doesn't
-   * support ANSI escape sequences.
-   *
-   * @param text - Text to display alongside the spinner (defaults to "Processing...")
-   * @param options - Optional spinner configuration (color, style, etc.)
-   *
-   * @example
-   * ```typescript
-   * log.startSpinner('Installing dependencies...');
-   * // ... perform work ...
-   * log.succeedSpinner('Dependencies installed!');
-   * ```
-   *
-   * @example With custom options
-   * ```typescript
-   * log.startSpinner('Deploying...', { color: 'yellow' });
-   * ```
-   */
-  startSpinner(text?: string, _options?: Omit<SpinnerOptions, 'text'>): void {
-    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
-      this.task(text || 'Processing...');
+  complete(type: 'success' | 'error' | 'warning' | 'info', text?: string): void {
+    if (!this.singleSpinnerListr) {
+      // When no spinner is active, fallback to the appropriate logger method
+      const completionText = text || this.getDefaultCompletionText(type);
+      switch (type) {
+        case 'success':
+          this.logger.success(completionText);
+          break;
+        case 'error':
+          this.logger.error(completionText);
+          break;
+        case 'warning':
+          this.logger.warning(completionText);
+          break;
+        case 'info':
+          this.logger.info(completionText);
+          break;
+      }
       return;
     }
 
-    // Stop any existing single spinner
-    this.stopSpinner();
-
-    const spinnerText = text || 'Processing...';
-
-    // Create a single task that will be managed as a multi-spinner with one item
-    const singleTask: ListrTask = {
-      title: spinnerText,
-      task: () => {
-        return new Promise<void>((resolve, reject) => {
-          this.singleSpinnerTask = { resolver: resolve, rejecter: reject };
-        });
-      },
+    const completionText = text || this.getDefaultCompletionText(type);
+    const completionMethods = {
+      success: () => SpinnerUtils.succeed('single', completionText),
+      error: () => SpinnerUtils.fail('single', completionText),
+      warning: () => SpinnerUtils.fail('single', completionText),
+      info: () => SpinnerUtils.info('single', completionText)
     };
 
-    // Create listr instance using the multi-spinner infrastructure
-    this.singleSpinnerListr = new Listr([singleTask], {
-      concurrent: false,
-      exitOnError: false,
-      renderer: DevLogrRenderer,
-      rendererOptions: {
-        prefix: this.prefix,
-        showTimestamp: this.config.showTimestamp,
-        useColors: this.config.useColors,
-        timestampFormat: this.config.timestampFormat,
-        supportsUnicode: this.config.supportsUnicode,
-      },
-    });
-
-    // Start the spinner task (don't await, let it run in background)
-    this.singleSpinnerListr.run().catch(() => {
-      // Handle errors silently, as they're expected when we complete with error
-    });
-  }
-
-  /**
-   * Update the text of the currently active spinner.
-   *
-   * @param text - New text to display with the spinner
-   */
-  updateSpinnerText(text: string): void {
-    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
-      return;
-    }
-
-    // Update the task title in the single spinner listr instance
-    if (this.singleSpinnerListr && this.singleSpinnerListr.tasks?.[0]) {
-      this.singleSpinnerListr.tasks[0].title = text;
-    }
-  }
-
-  /**
-   * Stop the current spinner without displaying any completion message.
-   */
-  stopSpinner(): void {
-    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
-      return;
-    }
-
-    // For manual stops, we don't want to show any completion symbol
-    // Instead of resolving, we'll clean up the state without resolving the Promise
-    // This should make the spinner disappear without showing success/failure
-    if (this.singleSpinnerListr) {
-      // Try to stop the listr renderer directly
-      try {
-        if ((this.singleSpinnerListr as any).renderer?.end) {
-          (this.singleSpinnerListr as any).renderer.end();
-        }
-      } catch (_error) {
-        // Ignore errors during cleanup
-      }
-    }
-
-    // Clean up state without resolving the Promise
+    completionMethods[type]();
     this.singleSpinnerListr = null;
     this.singleSpinnerTask = null;
   }
 
-  /**
-   * Complete the current spinner with a specific completion type and message.
-   *
-   * @param type - Type of completion (success, error, warning, info)
-   * @param text - Optional completion message (uses default if not provided)
-   */
-  completeSpinner(type: 'success' | 'error' | 'warning' | 'info', text?: string): void {
-    const completionText = text || this.getDefaultCompletionText(type);
+  private getDefaultCompletionText(type: 'success' | 'error' | 'warning' | 'info'): string {
+    const defaults = {
+      success: 'Done',
+      error: 'Failed',
+      warning: 'Warning',
+      info: 'Info',
+    };
+    return defaults[type];
+  }
+}
 
-    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
-      // In JSON mode or when spinners aren't supported, just log the message
-      this[type](completionText);
-      return;
-    }
+// ============================================================================
+// JSON LOGGER - EXTRACTED FOR SINGLE RESPONSIBILITY
+// ============================================================================
 
-    // If no spinner is active, fall back to regular logging
-    if (!this.singleSpinnerListr || !this.singleSpinnerTask) {
-      this[type](completionText);
-      return;
-    }
+class JsonLogger {
+  constructor(private readonly prefix: string) {}
 
-    // Update the task title with completion text and complete the spinner
-    if (this.singleSpinnerListr.tasks?.[0]) {
-      this.singleSpinnerListr.tasks[0].title = completionText;
-    }
-
-    // Complete the task based on type
-    if (type === 'error') {
-      if (this.singleSpinnerTask.rejecter) {
-        this.singleSpinnerTask.rejecter(new Error(completionText));
-      }
-    } else {
-      if (this.singleSpinnerTask.resolver) {
-        this.singleSpinnerTask.resolver();
-      }
-    }
-
-    // Clean up state
-    this.singleSpinnerListr = null;
-    this.singleSpinnerTask = null;
-
-    // No additional logging needed - the task title update handles the visual completion
+  log(level: LogLevel, message: string, args: unknown[]): void {
+    const logData = this.buildLogData(level, message, args);
+    const output = StringUtils.safeJsonStringify(logData, 0);
+    this.outputToConsole(level, output);
   }
 
-  /**
-   * Complete the current spinner with a success message.
-   *
-   * @param text - Optional success message
-   */
-  completeSpinnerWithSuccess(text?: string): void {
-    this.completeSpinner('success', text);
-  }
-
-  /**
-   * Complete the current spinner with an error message.
-   *
-   * @param text - Optional error message
-   */
-  completeSpinnerWithError(text?: string): void {
-    this.completeSpinner('error', text);
-  }
-
-  /**
-   * Complete the current spinner with a warning message.
-   *
-   * @param text - Optional warning message
-   */
-  completeSpinnerWithWarning(text?: string): void {
-    this.completeSpinner('warning', text);
-  }
-
-  /**
-   * Complete the current spinner with an info message.
-   *
-   * @param text - Optional info message
-   */
-  completeSpinnerWithInfo(text?: string): void {
-    this.completeSpinner('info', text);
-  }
-
-  /**
-   * Complete the current spinner with a success message (short alias).
-   *
-   * @param text - Optional success message
-   *
-   * @example
-   * ```typescript
-   * log.startSpinner('Uploading files...');
-   * log.succeedSpinner('Upload complete!');
-   * ```
-   */
-  succeedSpinner(text?: string): void {
-    this.completeSpinner('success', text);
-  }
-
-  /**
-   * Complete the current spinner with an error message (short alias).
-   *
-   * @param text - Optional error message
-   */
-  failSpinner(text?: string): void {
-    this.completeSpinner('error', text);
-  }
-
-  /**
-   * Complete the current spinner with a warning message (short alias).
-   *
-   * @param text - Optional warning message
-   */
-  warnSpinner(text?: string): void {
-    this.completeSpinner('warning', text);
-  }
-
-  /**
-   * Complete the current spinner with an info message (short alias).
-   *
-   * @param text - Optional info message
-   */
-  infoSpinner(text?: string): void {
-    this.completeSpinner('info', text);
-  }
-
-  // ============================================================================
-  // LISTR2 INTEGRATION METHODS
-  // ============================================================================
-
-  /**
-   * Execute a listr2 task list with proper logger integration
-   */
-  async runTasks<T = any>(
-    title: string,
-    tasks: ListrTask<T>[],
-    options?: {
-      concurrent?: boolean;
-      exitOnError?: boolean;
-      context?: T;
-      rendererOptions?: any;
-    }
-  ): Promise<T> {
-    // Show title with logger prefix
-    this.info(`${title}`);
-
-    if (this.config.useJson) {
-      // In JSON mode, just log task execution
-      this.debug('Executing tasks:', { title, taskCount: tasks.length });
-
-      // Execute tasks sequentially in JSON mode for consistent output
-      const context = options?.context || ({} as T);
-      for (const task of tasks) {
-        if (typeof task.task === 'function') {
-          try {
-            this.debug(`Starting task: ${task.title}`);
-            await task.task(context, {} as ListrTaskWrapper<T, any, any>);
-            this.info(`✓ ${task.title}`);
-          } catch (error) {
-            this.error(`✗ ${task.title}`, error);
-            if (options?.exitOnError !== false) {
-              throw error;
-            }
-          }
-        }
-      }
-      return context;
-    }
-
-    // Create listr2 instance with DevLogr renderer
-    const listr = new Listr(tasks, {
-      concurrent: options?.concurrent ?? false,
-      exitOnError: options?.exitOnError ?? true,
-      ctx: options?.context,
-      renderer: DevLogrRenderer,
-      rendererOptions: {
-        prefix: this.prefix,
-        showTimestamp: this.config.showTimestamp,
-        useColors: this.config.useColors,
-        timestampFormat: this.config.timestampFormat,
-        supportsUnicode: this.config.supportsUnicode,
-        ...options?.rendererOptions,
-      },
-      // Force our renderer to be used even in non-TTY environments (CI)
-      fallbackRenderer: DevLogrRenderer,
-      fallbackRendererCondition: false, // Never fallback to a different renderer
-      silentRendererCondition: false, // Never use silent renderer
-    });
-
-    try {
-      const result = await listr.run();
-      this.success(`${title} completed successfully`);
-      return result;
-    } catch (error) {
-      this.error(`${title} failed`, error);
-      throw error;
-    }
-  }
-
-  /**
-   * Create a task list with the logger's prefix integration
-   */
-  createTaskList<T = any>(
-    tasks: ListrTask<T>[],
-    options?: {
-      concurrent?: boolean;
-      exitOnError?: boolean;
-      context?: T;
-      taskLevel?: string;
-    }
-  ): Listr<T, typeof DevLogrRenderer> {
-    return new Listr(tasks, {
-      concurrent: options?.concurrent ?? false,
-      exitOnError: options?.exitOnError ?? true,
-      ctx: options?.context,
-      renderer: DevLogrRenderer,
-      rendererOptions: {
-        prefix: this.prefix,
-        showTimestamp: this.config.showTimestamp,
-        useColors: this.config.useColors,
-        timestampFormat: this.config.timestampFormat,
-        supportsUnicode: this.config.supportsUnicode,
-        taskLevel: options?.taskLevel,
-      },
-      // Force our renderer to be used even in non-TTY environments (CI)
-      fallbackRenderer: DevLogrRenderer,
-      fallbackRendererCondition: false, // Never fallback to a different renderer
-      silentRendererCondition: false, // Never use silent renderer
-    });
-  }
-
-  /**
-   * Execute concurrent tasks with proper logging
-   */
-  async runConcurrentTasks<T = any>(
-    title: string,
-    tasks: ListrTask<T>[],
-    contextOrOptions?: T | { context?: T; taskLevel?: string }
-  ): Promise<T> {
-    // Handle both signatures for backward compatibility
-    let context: T | undefined;
-    let taskLevel: string | undefined;
-
-    // Check if it's an options object by looking for known option properties
-    if (
-      contextOrOptions &&
-      typeof contextOrOptions === 'object' &&
-      ('context' in contextOrOptions || 'taskLevel' in contextOrOptions)
-    ) {
-      const options = contextOrOptions as { context?: T; taskLevel?: string };
-      context = options.context;
-      taskLevel = options.taskLevel;
-    } else {
-      context = contextOrOptions as T;
-    }
-
-    return this.runTasks(title, tasks, {
-      concurrent: true,
-      exitOnError: false,
-      context,
-      rendererOptions: { taskLevel },
-    });
-  }
-
-  /**
-   * Execute sequential tasks with proper logging
-   */
-  async runSequentialTasks<T = any>(
-    title: string,
-    tasks: ListrTask<T>[],
-    contextOrOptions?: T | { context?: T; taskLevel?: string }
-  ): Promise<T> {
-    // Handle both signatures for backward compatibility
-    let context: T | undefined;
-    let taskLevel: string | undefined;
-
-    // Check if it's an options object by looking for known option properties
-    if (
-      contextOrOptions &&
-      typeof contextOrOptions === 'object' &&
-      ('context' in contextOrOptions || 'taskLevel' in contextOrOptions)
-    ) {
-      const options = contextOrOptions as { context?: T; taskLevel?: string };
-      context = options.context;
-      taskLevel = options.taskLevel;
-    } else {
-      context = contextOrOptions as T;
-    }
-
-    return this.runTasks(title, tasks, {
-      concurrent: false,
-      exitOnError: true,
-      context,
-      rendererOptions: { taskLevel },
-    });
-  }
-
-  // ============================================================================
-  // UTILITY METHODS
-  // ============================================================================
-
-  spacer(): void {
-    if (!this.config.useJson) {
-      console.log();
-    }
-  }
-
-  separator(title?: string): void {
-    if (this.config.useJson) {
-      return;
-    }
-
-    const width = 50;
-    const line = title
-      ? `--- ${title} ${'-'.repeat(Math.max(0, width - title.length - 8))}`
-      : '-'.repeat(width);
-
-    const coloredLine = ChalkUtils.colorize(line, 'dim', this.config.useColors);
-    console.log(coloredLine);
-  }
-
-  // ============================================================================
-  // PRIVATE IMPLEMENTATION METHODS
-  // ============================================================================
-
-  private getEffectiveLevel(): LogLevel {
-    return Logger.globalLevel ?? this.config.level;
-  }
-
-  private shouldLog(level: LogLevel): boolean {
-    const levels = [
-      LogLevel.ERROR,
-      LogLevel.WARNING,
-      LogLevel.INFO,
-      LogLevel.DEBUG,
-      LogLevel.TRACE,
-    ];
-    const effectiveLevel = this.getEffectiveLevel();
-    const currentIndex = levels.indexOf(level);
-    const effectiveIndex = levels.indexOf(effectiveLevel);
-    return currentIndex <= effectiveIndex;
-  }
-
-  private log(level: LogLevel, logLevel: string, message: string, ...args: unknown[]): void {
-    if (!this.shouldLog(level)) {
-      return;
-    }
-
-    if (this.config.useJson) {
-      this.logJson(level, message, args);
-    } else {
-      this.logFormatted(level, logLevel, message, args);
-    }
-  }
-
-  private logJson(level: LogLevel, message: string, args: unknown[]): void {
-    const logData = this.buildJsonLogData(level, message, args);
-    this.outputToConsole(level, StringUtils.safeJsonStringify(logData, 0));
-  }
-
-  private buildJsonLogData(
-    level: LogLevel,
-    message: string,
-    args: unknown[]
-  ): Record<string, unknown> {
-    // In JSON mode, always strip emojis for clean machine-readable output
-    const shouldStripEmojis = true;
+  private buildLogData(level: LogLevel, message: string, args: unknown[]): Record<string, unknown> {
+    const shouldStripEmojis = true; // Always strip emojis in JSON mode
     const finalMessage = shouldStripEmojis ? EmojiUtils.forceStripEmojis(message) : message;
 
     const logData: Record<string, unknown> = {
@@ -679,7 +111,7 @@ export class Logger {
       timestamp: new Date().toISOString(),
     };
 
-    // Add arguments to log data with emoji stripping
+    // Add arguments to log data
     args.forEach((arg, index) => {
       if (this.isPlainObject(arg) && !this.hasCircularReferences(arg)) {
         this.mergeObjectArg(logData, arg as Record<string, unknown>, index, shouldStripEmojis);
@@ -728,6 +160,342 @@ export class Logger {
     logData[`arg${index}`] = arg;
   }
 
+  private outputToConsole(level: LogLevel, message: string): void {
+    switch (level) {
+      case LogLevel.ERROR:
+        console.error(message);
+        break;
+      case LogLevel.WARNING:
+        console.warn(message);
+        break;
+      case LogLevel.DEBUG:
+      case LogLevel.TRACE:
+        console.debug(message);
+        break;
+      default:
+        console.log(message);
+        break;
+    }
+  }
+}
+
+// ============================================================================
+// TASK RUNNER - EXTRACTED FOR SINGLE RESPONSIBILITY
+// ============================================================================
+
+class TaskRunner {
+  constructor(private readonly logger: Logger) {}
+
+  async runTasks<T = any>(
+    title: string,
+    tasks: ListrTask<T>[],
+    options: {
+      concurrent?: boolean;
+      exitOnError?: boolean;
+      context?: T;
+      rendererOptions?: any;
+    } = {}
+  ): Promise<T> {
+    const { concurrent = false, exitOnError = true, context, rendererOptions } = options;
+    
+    const listr = this.createTaskList(tasks, {
+      concurrent,
+      exitOnError,
+      context,
+      taskLevel: 'task',
+    });
+
+    try {
+      const result = await listr.run(context);
+      this.logger.outputDevLogrFormattedTask(`${title} completed successfully`, '✔');
+      return result;
+    } catch (error) {
+      this.logger.outputDevLogrFormattedTask(`${title} failed`, '✖');
+      throw error;
+    }
+  }
+
+  createTaskList<T = any>(
+    tasks: ListrTask<T>[],
+    options: {
+      concurrent?: boolean;
+      exitOnError?: boolean;
+      context?: T;
+      taskLevel?: string;
+    } = {}
+  ): Listr<T, typeof DevLogrRenderer> {
+    const { concurrent = false, exitOnError = true, context, taskLevel = 'task' } = options;
+    
+    return new Listr(tasks, {
+      concurrent,
+      exitOnError,
+      renderer: DevLogrRenderer,
+      rendererOptions: {
+        prefix: this.logger.getPrefix(),
+        showTimestamp: this.logger.getConfig().showTimestamp,
+        useColors: this.logger.getConfig().useColors,
+        timestampFormat: this.logger.getConfig().timestampFormat,
+        supportsUnicode: this.logger.getConfig().supportsUnicode,
+        taskLevel,
+      },
+    }) as Listr<T, typeof DevLogrRenderer>;
+  }
+}
+
+// ============================================================================
+// LOGGER IMPLEMENTATION - SIMPLIFIED AND FOCUSED
+// ============================================================================
+
+/**
+ * Main DevLogr Logger class providing structured logging with visual enhancements.
+ * Now simplified with extracted responsibilities for better maintainability.
+ */
+export class Logger {
+  private readonly prefix: string;
+  private readonly config: LogConfig;
+  private static globalLevel?: LogLevel;
+  private readonly spinnerManager: SpinnerManager;
+  private readonly jsonLogger: JsonLogger;
+  private readonly taskRunner: TaskRunner;
+
+  constructor(prefix: string) {
+    this.prefix = prefix;
+    this.config = LogConfiguration.getConfig();
+    this.spinnerManager = new SpinnerManager(this);
+    this.jsonLogger = new JsonLogger(prefix);
+    this.taskRunner = new TaskRunner(this);
+    PrefixTracker.register(prefix);
+  }
+
+  // ============================================================================
+  // STATIC LEVEL MANAGEMENT
+  // ============================================================================
+
+  static setLevel(level: LogLevel): void {
+    Logger.globalLevel = level;
+  }
+
+  static resetLevel(): void {
+    Logger.globalLevel = undefined;
+  }
+
+  // ============================================================================
+  // CORE LOGGING METHODS - SIMPLIFIED WITH DELEGATION
+  // ============================================================================
+
+  info(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, 'info', message, ...args);
+  }
+
+  error(message: string, error?: unknown, ...args: unknown[]): void {
+    const allArgs = error ? [error, ...args] : args;
+    this.log(LogLevel.ERROR, 'error', message, ...allArgs);
+  }
+
+  warning(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.WARNING, 'warn', message, ...args);
+  }
+
+  warn(message: string, ...args: unknown[]): void {
+    this.warning(message, ...args);
+  }
+
+  debug(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.DEBUG, 'debug', message, ...args);
+  }
+
+  trace(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.TRACE, 'trace', message, ...args);
+  }
+
+  success(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, 'success', message, ...args);
+  }
+
+  title(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, 'title', message, ...args);
+  }
+
+  task(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, 'task', message, ...args);
+  }
+
+  plain(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, 'plain', message, ...args);
+  }
+
+  // ============================================================================
+  // SPINNER METHODS - DELEGATED TO SPINNER MANAGER
+  // ============================================================================
+
+  startSpinner(text?: string, options?: Omit<SpinnerOptions, 'text'>): void {
+    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
+      this.task(text || 'Loading...');
+      return;
+    }
+    this.spinnerManager.start(text, options);
+  }
+
+  updateSpinnerText(text: string): void {
+    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
+      return;
+    }
+    this.spinnerManager.updateText(text);
+  }
+
+  stopSpinner(): void {
+    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
+      return;
+    }
+    this.spinnerManager.stop();
+  }
+
+  // Simplified completion methods using delegation
+  completeSpinner(type: 'success' | 'error' | 'warning' | 'info', text?: string): void {
+    if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
+      // Fallback to regular logging using the correct method names
+      const completionText = text || this.getDefaultCompletionText(type);
+      switch (type) {
+        case 'success':
+          this.success(completionText);
+          break;
+        case 'error':
+          this.error(completionText);
+          break;
+        case 'warning':
+          this.warning(completionText);
+          break;
+        case 'info':
+          this.info(completionText);
+          break;
+      }
+      return;
+    }
+    this.spinnerManager.complete(type, text);
+  }
+
+  // Convenience methods - simplified
+  completeSpinnerWithSuccess(text?: string): void { this.completeSpinner('success', text); }
+  completeSpinnerWithError(text?: string): void { this.completeSpinner('error', text); }
+  completeSpinnerWithWarning(text?: string): void { this.completeSpinner('warning', text); }
+  completeSpinnerWithInfo(text?: string): void { this.completeSpinner('info', text); }
+  succeedSpinner(text?: string): void { this.completeSpinner('success', text); }
+  failSpinner(text?: string): void { this.completeSpinner('error', text); }
+  warnSpinner(text?: string): void { this.completeSpinner('warning', text); }
+  infoSpinner(text?: string): void { this.completeSpinner('info', text); }
+
+  // ============================================================================
+  // TASK METHODS - DELEGATED TO TASK RUNNER
+  // ============================================================================
+
+  async runTasks<T = any>(
+    title: string,
+    tasks: ListrTask<T>[],
+    options?: {
+      concurrent?: boolean;
+      exitOnError?: boolean;
+      context?: T;
+      rendererOptions?: any;
+    }
+  ): Promise<T> {
+    return this.taskRunner.runTasks(title, tasks, options);
+  }
+
+  createTaskList<T = any>(
+    tasks: ListrTask<T>[],
+    options?: {
+      concurrent?: boolean;
+      exitOnError?: boolean;
+      context?: T;
+      taskLevel?: string;
+    }
+  ): Listr<T, typeof DevLogrRenderer> {
+    return this.taskRunner.createTaskList(tasks, options);
+  }
+
+  // Simplified task methods using the base runTasks
+  async runConcurrentTasks<T = any>(
+    title: string,
+    tasks: ListrTask<T>[],
+    contextOrOptions?: T | { context?: T; taskLevel?: string }
+  ): Promise<T> {
+    const options = this.normalizeTaskOptions(contextOrOptions, true);
+    return this.runTasks(title, tasks, options);
+  }
+
+  async runSequentialTasks<T = any>(
+    title: string,
+    tasks: ListrTask<T>[],
+    contextOrOptions?: T | { context?: T; taskLevel?: string }
+  ): Promise<T> {
+    const options = this.normalizeTaskOptions(contextOrOptions, false);
+    return this.runTasks(title, tasks, options);
+  }
+
+  // ============================================================================
+  // UTILITY METHODS
+  // ============================================================================
+
+  spacer(): void {
+    if (!this.config.useJson) {
+      console.log();
+    }
+  }
+
+  separator(title?: string): void {
+    if (this.config.useJson) {
+      return;
+    }
+
+    const SEPARATOR_LENGTH = 60; // Fixed total length
+    const dashChar = this.config.supportsUnicode ? '─' : '-';
+    
+    if (title) {
+      // Format: "-- Title ------------------" (fixed total length)
+      const prefix = `${dashChar}${dashChar} ${title} `;
+      const remainingLength = Math.max(0, SEPARATOR_LENGTH - prefix.length);
+      const suffix = StringUtils.repeat(dashChar, remainingLength);
+      const fullSeparator = `${prefix}${suffix}`;
+      
+      // Apply gray color
+      const grayedSeparator = ChalkUtils.colorize(fullSeparator, 'dim', this.config.useColors);
+      console.log(grayedSeparator);
+    } else {
+      // Plain separator line (fixed length)
+      const separator = StringUtils.repeat(dashChar, SEPARATOR_LENGTH);
+      const grayedSeparator = ChalkUtils.colorize(separator, 'dim', this.config.useColors);
+      console.log(grayedSeparator);
+    }
+  }
+
+  // ============================================================================
+  // CORE PRIVATE METHODS - SIMPLIFIED
+  // ============================================================================
+
+  private getEffectiveLevel(): LogLevel {
+    return Logger.globalLevel ?? this.config.level;
+  }
+
+  private shouldLog(level: LogLevel): boolean {
+    const levels = [LogLevel.ERROR, LogLevel.WARNING, LogLevel.INFO, LogLevel.DEBUG, LogLevel.TRACE];
+    const effectiveLevel = this.getEffectiveLevel();
+    const currentIndex = levels.indexOf(level);
+    const effectiveIndex = levels.indexOf(effectiveLevel);
+    return currentIndex <= effectiveIndex;
+  }
+
+  log(level: LogLevel, logLevel: string, message: string, ...args: unknown[]): void {
+    if (!this.shouldLog(level)) {
+      return;
+    }
+
+    if (this.config.useJson) {
+      this.jsonLogger.log(level, message, args);
+    } else {
+      this.logFormatted(level, logLevel, message, args);
+    }
+  }
+
   private logFormatted(level: LogLevel, logLevel: string, message: string, args: unknown[]): void {
     const formattedMessage = this.formatMessage(logLevel, message, args);
     this.outputToConsole(level, formattedMessage);
@@ -736,12 +504,8 @@ export class Logger {
   private formatMessage(level: string, message: string, args: unknown[]): string {
     const theme = ThemeProvider.getTheme(level, undefined, this.config.supportsUnicode);
     const maxPrefixLength = PrefixTracker.getMaxLength();
-
     const shouldStripEmojis = !EmojiUtils.supportsEmoji();
-    let finalMessage = message;
-    if (shouldStripEmojis) {
-      finalMessage = EmojiUtils.forceStripEmojis(message);
-    }
+    const finalMessage = shouldStripEmojis ? EmojiUtils.forceStripEmojis(message) : message;
 
     return MessageFormatter.format({
       level,
@@ -760,28 +524,19 @@ export class Logger {
   }
 
   private outputToConsole(level: LogLevel, message: string): void {
-    switch (level) {
-      case LogLevel.ERROR:
-        console.error(message);
-        break;
-      case LogLevel.WARNING:
-        console.warn(message);
-        break;
-      case LogLevel.DEBUG:
-      case LogLevel.TRACE:
-        console.debug(message);
-        break;
-      default:
-        console.log(message);
-        break;
-    }
+    const outputMethods: Record<string, (message: string) => void> = {
+      [LogLevel.ERROR]: console.error,
+      [LogLevel.WARNING]: console.warn,
+      [LogLevel.DEBUG]: console.debug,
+      [LogLevel.TRACE]: console.debug,
+    };
+    
+    const outputMethod = outputMethods[level] || console.log;
+    outputMethod(message);
   }
 
-  private buildSpinnerOptions(
-    text: string,
-    level: string,
-    options?: Omit<SpinnerOptions, 'text'>
-  ): SpinnerOptions {
+  // Helper methods for extracted classes
+  buildSpinnerOptions(text: string, level: string, options?: Omit<SpinnerOptions, 'text'>): SpinnerOptions {
     const theme = ThemeProvider.getTheme(level, undefined, this.config.supportsUnicode);
     return {
       text,
@@ -796,23 +551,11 @@ export class Logger {
     };
   }
 
-  private getDefaultCompletionText(type: 'success' | 'error' | 'warning' | 'info'): string {
-    const defaults = {
-      success: 'Done',
-      error: 'Failed',
-      warning: 'Warning',
-      info: 'Info',
-    };
-    return defaults[type];
-  }
-
-  private buildListrPrefix(): string {
-    // Build a prefix that matches the logger's format for listr2 tasks
-    // Use 'task' level theme for listr2 items as they represent ongoing operations
+  outputDevLogrFormattedTask(message: string, symbol?: string): void {
     const theme = ThemeProvider.getTheme('task', undefined, this.config.supportsUnicode);
     const maxPrefixLength = PrefixTracker.getMaxLength();
 
-    return MessageFormatter.format({
+    const prefix = MessageFormatter.format({
       level: 'task',
       theme,
       prefix: this.prefix,
@@ -824,45 +567,58 @@ export class Logger {
       includeLevel: this.config.showPrefix,
       includePrefix: this.config.showPrefix,
     });
+
+    const cleanPrefix = prefix.replace(/\s+$/, '');
+    const formattedMessage = symbol ? `${cleanPrefix} ${symbol} ${message}` : `${cleanPrefix} ${message}`;
+    console.log(formattedMessage);
   }
 
-  private outputDevLogrFormattedTask(message: string, symbol?: string): void {
-    const prefix = this.buildListrPrefix();
-    // Remove the trailing space from prefix and add symbol after it
-    const cleanPrefix = prefix.replace(/\s+$/, '');
-    const formattedMessage = symbol
-      ? `${cleanPrefix} ${symbol} ${message}`
-      : `${cleanPrefix} ${message}`;
-    console.log(formattedMessage);
+  private normalizeTaskOptions<T>(
+    contextOrOptions?: T | { context?: T; taskLevel?: string },
+    concurrent = false
+  ): { concurrent: boolean; context?: T } {
+    if (!contextOrOptions) {
+      return { concurrent };
+    }
+    
+    if (typeof contextOrOptions === 'object' && contextOrOptions !== null && 'context' in contextOrOptions) {
+      return { concurrent, context: (contextOrOptions as { context?: T }).context };
+    }
+    
+    return { concurrent, context: contextOrOptions as T };
+  }
+
+  // Public getters for extracted classes
+  getConfig(): LogConfig {
+    return this.config;
+  }
+
+  getPrefix(): string {
+    return this.prefix;
+  }
+
+  // Getter for tests to check spinner state
+  get singleSpinnerListr(): Listr | null {
+    return (this.spinnerManager as any).singleSpinnerListr;
+  }
+
+  // ============================================================================
+  // PRIVATE HELPER METHODS
+  // ============================================================================
+
+  private getDefaultCompletionText(type: 'success' | 'error' | 'warning' | 'info'): string {
+    const defaults = {
+      success: 'Done',
+      error: 'Failed',
+      warning: 'Warning',
+      info: 'Info',
+    };
+    return defaults[type];
   }
 }
 
 /**
  * Factory function to create a new Logger instance with the specified prefix.
- *
- * This is the recommended way to create logger instances. The prefix helps
- * identify log messages from different parts of your application and is used
- * for spinner management.
- *
- * @param prefix - Unique identifier for this logger instance (e.g., 'api', 'deploy', 'build')
- * @returns A new Logger instance configured with the specified prefix
- *
- * @example
- * ```typescript
- * import { createLogger } from '@neofork/devlogr';
- *
- * const log = createLogger('my-app');
- * log.info('Application starting...');
- * ```
- *
- * @example Multiple loggers
- * ```typescript
- * const apiLog = createLogger('api');
- * const dbLog = createLogger('database');
- *
- * apiLog.info('Server started on port 3000');
- * dbLog.info('Connected to database');
- * ```
  */
 export function createLogger(prefix: string): Logger {
   return new Logger(prefix);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -340,7 +340,8 @@ export class Logger {
 
   startSpinner(text?: string, options?: Omit<SpinnerOptions, 'text'>): void {
     if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
-      this.task(text || 'Loading...');
+      // In non-TTY environments, don't output the working state to avoid double output
+      // Only the completion state will be shown when succeedSpinner/failSpinner is called
       return;
     }
     this.spinnerManager.start(text, options);

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -381,6 +381,7 @@ export class Logger {
       }
       return;
     }
+    // Delegate to spinner manager which handles its own fallback logic
     this.spinnerManager.complete(type, text);
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -592,10 +592,14 @@ export class Logger {
       ...((options.rendererOptions as Record<string, unknown>) || {}),
     };
 
+    const theme = ThemeProvider.getTheme(level, undefined, this.config.supportsUnicode);
+
     return {
       text,
       level,
       prefix: this.prefix,
+      useColors: this.config.useColors,
+      theme,
       rendererOptions: _rendererOptions as Record<string, unknown>,
       ...options,
     };

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -555,7 +555,7 @@ export class Logger {
       concurrent: true,
       exitOnError: false,
       context,
-      rendererOptions: taskLevel ? { taskLevel } : undefined,
+      rendererOptions: { taskLevel },
     });
   }
 
@@ -588,7 +588,7 @@ export class Logger {
       concurrent: false,
       exitOnError: true,
       context,
-      rendererOptions: taskLevel ? { taskLevel } : undefined,
+      rendererOptions: { taskLevel },
     });
   }
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -340,8 +340,7 @@ export class Logger {
 
   startSpinner(text?: string, options?: Omit<SpinnerOptions, 'text'>): void {
     if (this.config.useJson || !SpinnerUtils.supportsSpinners()) {
-      // In non-TTY environments, don't output the working state to avoid double output
-      // Only the completion state will be shown when succeedSpinner/failSpinner is called
+      this.task(text || 'Loading...');
       return;
     }
     this.spinnerManager.start(text, options);

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -85,7 +85,7 @@ export class ThemeProvider {
    */
   private static getColorFunction(
     defaultColorName: string,
-    customColor?: any,
+    customColor?: (text: string) => string,
     useColors = true
   ): (text: string) => string {
     if (customColor) {
@@ -108,5 +108,19 @@ export class ThemeProvider {
    */
   static getFallbackTheme(level: string): LogTheme {
     return this.getTheme(level, undefined, false);
+  }
+
+  private static applyColorToTheme(
+    theme: LogTheme,
+    colorName: string,
+    useColors: boolean
+  ): LogTheme {
+    const colorFunction =
+      (ChalkUtils as Record<string, (text: string) => string>)[colorName] ||
+      ((text: string) => text);
+    return {
+      ...theme,
+      color: useColors ? colorFunction : (text: string) => text,
+    };
   }
 }

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -115,9 +115,7 @@ export class ThemeProvider {
     colorName: string,
     useColors: boolean
   ): LogTheme {
-    const colorFunction =
-      (ChalkUtils as Record<string, (text: string) => string>)[colorName] ||
-      ((text: string) => text);
+    const colorFunction = (ChalkUtils as any)[colorName] || ((text: string) => text);
     return {
       ...theme,
       color: useColors ? colorFunction : (text: string) => text,

--- a/src/themes.ts
+++ b/src/themes.ts
@@ -3,16 +3,10 @@ import { TerminalUtils } from './utils';
 import { LogConfiguration } from './config';
 import { ChalkUtils } from './utils/chalk';
 
-// ============================================================================
-// THEME MANAGEMENT - SIMPLIFIED
-// ============================================================================
-
 /**
- * Simplified ThemeProvider with consolidated theme and color management.
- * Reduces duplication by using centralized color and symbol mapping.
+ * Theme management for log levels with color and symbol mapping.
  */
 export class ThemeProvider {
-  // Centralized theme definitions to reduce duplication
   private static readonly THEME_DEFINITIONS = {
     error: { symbol: '✗', color: 'red', label: 'ERROR' },
     warn: { symbol: '!', color: 'yellow', label: 'WARN' },
@@ -25,10 +19,6 @@ export class ThemeProvider {
     plain: { symbol: ' ', color: 'white', label: 'PLAIN' },
   } as const;
 
-  /**
-   * Gets theme for specified log level with automatic configuration handling.
-   * Simplified to use centralized theme definitions and color mapping.
-   */
   static getTheme(
     level: string,
     customThemes?: Record<string, Partial<LogTheme>>,
@@ -49,40 +39,29 @@ export class ThemeProvider {
     };
   }
 
-  /**
-   * Gets appropriate symbol based on configuration and Unicode support.
-   */
   private static getSymbol(
     level: string,
     customSymbol?: string,
     supportsUnicode = true,
     showIcons = true
   ): string {
-    // If icons are disabled, return empty string
     if (!showIcons) {
       return '';
     }
 
-    // If custom symbol is provided, use it as-is
     if (customSymbol !== undefined) {
       return customSymbol;
     }
 
-    // Use fallback symbols if Unicode is not supported
     if (!supportsUnicode) {
       const fallbackSymbols = TerminalUtils.getFallbackSymbols();
       return fallbackSymbols[level] || '';
     }
 
-    // Use Unicode symbols from theme definitions
     const themeDefinition = this.THEME_DEFINITIONS[level as keyof typeof this.THEME_DEFINITIONS];
     return themeDefinition?.symbol || '';
   }
 
-  /**
-   * Gets color function using centralized mapping.
-   * Simplified to reduce duplication between ThemeProvider and ChalkUtils.
-   */
   private static getColorFunction(
     defaultColorName: string,
     customColor?: (text: string) => string,
@@ -92,20 +71,13 @@ export class ThemeProvider {
       return customColor;
     }
 
-    // Use ChalkUtils for consistent color handling
     return (text: string) => ChalkUtils.colorize(text, defaultColorName, useColors);
   }
 
-  /**
-   * Gets all available theme names.
-   */
   static getAvailableThemes(): string[] {
     return Object.keys(this.THEME_DEFINITIONS);
   }
 
-  /**
-   * Gets fallback theme without Unicode symbols.
-   */
   static getFallbackTheme(level: string): LogTheme {
     return this.getTheme(level, undefined, false);
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -87,6 +87,9 @@ export interface LogConfig {
   /** Whether the terminal supports emoji characters */
   readonly supportsEmoji: boolean;
 
+  /** Whether to show emojis in output (user preference) */
+  readonly showEmojis: boolean;
+
   /** Whether to include timestamps in log messages */
   readonly showTimestamp: boolean;
 

--- a/src/types/spinner.ts
+++ b/src/types/spinner.ts
@@ -1,0 +1,59 @@
+/**
+ * Interface for spinner implementations following Interface Segregation Principle.
+ * Defines the contract for both single and multi-spinner implementations.
+ */
+export interface ISpinner {
+  /**
+   * Start a spinner with the given text.
+   * @param text - The text to display with the spinner
+   */
+  start(text: string): void;
+
+  /**
+   * Stop the spinner without any completion message.
+   */
+  stop(): void;
+
+  /**
+   * Complete the spinner with a success status.
+   * @param text - Optional completion text
+   */
+  succeed(text?: string): void;
+
+  /**
+   * Complete the spinner with a failure status.
+   * @param text - Optional failure text
+   */
+  fail(text?: string): void;
+
+  /**
+   * Complete the spinner with a warning status.
+   * @param text - Optional warning text
+   */
+  warn(text?: string): void;
+
+  /**
+   * Complete the spinner with an info status.
+   * @param text - Optional info text
+   */
+  info(text?: string): void;
+
+  /**
+   * Update the spinner text while it's running.
+   * @param text - New text to display
+   */
+  updateText(text: string): void;
+
+  /**
+   * Check if the spinner is currently active.
+   * @returns True if spinner is running, false otherwise
+   */
+  isActive(): boolean;
+
+  /**
+   * Set the logger prefix for consistent formatting (optional method).
+   * Not all spinner implementations may need this.
+   * @param prefix - The logger prefix to use
+   */
+  setPrefix?(prefix: string): void;
+}

--- a/src/types/spinner.ts
+++ b/src/types/spinner.ts
@@ -1,59 +1,22 @@
 /**
- * Interface for spinner implementations following Interface Segregation Principle.
- * Defines the contract for both single and multi-spinner implementations.
+ * Interface for spinner implementations.
  */
 export interface ISpinner {
-  /**
-   * Start a spinner with the given text.
-   * @param text - The text to display with the spinner
-   */
   start(text: string): void;
 
-  /**
-   * Stop the spinner without any completion message.
-   */
   stop(): void;
 
-  /**
-   * Complete the spinner with a success status.
-   * @param text - Optional completion text
-   */
   succeed(text?: string): void;
 
-  /**
-   * Complete the spinner with a failure status.
-   * @param text - Optional failure text
-   */
   fail(text?: string): void;
 
-  /**
-   * Complete the spinner with a warning status.
-   * @param text - Optional warning text
-   */
   warn(text?: string): void;
 
-  /**
-   * Complete the spinner with an info status.
-   * @param text - Optional info text
-   */
   info(text?: string): void;
 
-  /**
-   * Update the spinner text while it's running.
-   * @param text - New text to display
-   */
   updateText(text: string): void;
 
-  /**
-   * Check if the spinner is currently active.
-   * @returns True if spinner is running, false otherwise
-   */
   isActive(): boolean;
 
-  /**
-   * Set the logger prefix for consistent formatting (optional method).
-   * Not all spinner implementations may need this.
-   * @param prefix - The logger prefix to use
-   */
   setPrefix?(prefix: string): void;
 }

--- a/src/utils/chalk.ts
+++ b/src/utils/chalk.ts
@@ -1,16 +1,16 @@
-import chalk, { ChalkInstance } from 'chalk';
+import chalk, { Chalk } from 'chalk';
 
 /**
  * Centralized chalk utility that handles color override logic
  */
 export class ChalkUtils {
-  private static cachedChalk: ChalkInstance;
+  private static cachedChalk: Chalk;
   private static lastColorSetting: boolean | undefined;
 
   /**
    * Gets a chalk instance with appropriate color override logic
    */
-  static getChalkInstance(useColors?: boolean): ChalkInstance {
+  static getChalkInstance(useColors?: boolean): Chalk {
     // Get current color setting, with fallback if LogConfiguration is not available
     let currentUseColors: boolean;
     try {

--- a/src/utils/chalk.ts
+++ b/src/utils/chalk.ts
@@ -1,16 +1,16 @@
-import chalk from 'chalk';
+import chalk, { ChalkInstance } from 'chalk';
 
 /**
  * Centralized chalk utility that handles color override logic
  */
 export class ChalkUtils {
-  private static cachedChalk: any;
+  private static cachedChalk: ChalkInstance;
   private static lastColorSetting: boolean | undefined;
 
   /**
    * Gets a chalk instance with appropriate color override logic
    */
-  static getChalkInstance(useColors?: boolean): any {
+  static getChalkInstance(useColors?: boolean): ChalkInstance {
     // Get current color setting, with fallback if LogConfiguration is not available
     let currentUseColors: boolean;
     try {

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -5,8 +5,9 @@ import { LogConfiguration } from '../config';
  */
 export class EmojiUtils {
   // More precise emoji regex that excludes useful Unicode symbols like ✓, ✗, ℹ, →, etc.
+  // Includes keycap sequences and complex multi-part emojis
   private static readonly EMOJI_REGEX =
-    /(?:[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E6}-\u{1F1FF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{1FA70}-\u{1FAFF}]|[\u{2640}-\u{2642}]|[\u{2695}]|[\u{26A0}]|[\u{26BD}]|[\u{26BE}]|[\u{26C4}]|[\u{26C5}]|[\u{26CE}]|[\u{26D4}]|[\u{26EA}]|[\u{26F2}]|[\u{26F3}]|[\u{26F5}]|[\u{26FA}]|[\u{26FD}]|[\u{2705}]|[\u{270A}]|[\u{270B}]|[\u{2728}]|[\u{274C}]|[\u{274E}]|[\u{2753}-\u{2755}]|[\u{2757}]|[\u{2795}-\u{2797}]|[\u{27B0}]|[\u{27BF}]|[\u{2B1B}]|[\u{2B1C}]|[\u{2B50}]|[\u{2B55}]|🚀|🎉|🌟|💡|⚡|🔥|❤️|💙|💚|💛|💜|🧡|🖤|🤍|🤎|💯|✨)+/gu;
+    /(?:[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E6}-\u{1F1FF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{1FA70}-\u{1FAFF}]|[\u{2640}-\u{2642}]|[\u{2695}]|[\u{26A0}]|[\u{26BD}]|[\u{26BE}]|[\u{26C4}]|[\u{26C5}]|[\u{26CE}]|[\u{26D4}]|[\u{26EA}]|[\u{26F2}]|[\u{26F3}]|[\u{26F5}]|[\u{26FA}]|[\u{26FD}]|[\u{2705}]|[\u{270A}]|[\u{270B}]|[\u{2728}]|[\u{274C}]|[\u{274E}]|[\u{2753}-\u{2755}]|[\u{2757}]|[\u{2795}-\u{2797}]|[\u{27B0}]|[\u{27BF}]|[\u{2B1B}]|[\u{2B1C}]|[\u{2B50}]|[\u{2B55}]|[\u{FE0E}\u{FE0F}]|🚀|🎉|🌟|💡|⚡|🔥|❤️|💙|💚|💛|💜|🧡|🖤|🤍|🤎|💯|✨|[0-9#*][\u{FE0F}]?[\u{20E3}])+/gu;
 
   // Preserve useful Unicode symbols while removing emojis and fixing spaces
   private static processEmojisAndFixSpaces(input: string): string {
@@ -29,14 +30,17 @@ export class EmojiUtils {
    * Keeps all the existing CI adaptation and terminal detection logic
    */
   static supportsEmoji(): boolean {
+    // Check for explicit disable flags (global standards)
     if (process.env.NO_COLOR !== undefined || process.env.NO_EMOJI !== undefined) {
       return false;
     }
 
-    if (process.env.DEVLOGR_NO_COLOR || process.env.DEVLOGR_NO_EMOJI) {
-      return false;
+    // Check for devlogr-specific show emoji setting
+    if (process.env.DEVLOGR_SHOW_EMOJI !== undefined) {
+      return process.env.DEVLOGR_SHOW_EMOJI === 'true' || process.env.DEVLOGR_SHOW_EMOJI === '1';
     }
 
+    // If explicitly enabled with colors
     if (process.env.DEVLOGR_FORCE_COLOR || process.env.FORCE_COLOR) {
       return true;
     }

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -1,82 +1,56 @@
 /**
- * Emoji detection and handling utilities for terminal output.
- * Automatically detects terminal support and provides fallbacks.
+ * Emoji utilities for terminal output with automatic detection.
  */
 export class EmojiUtils {
-  // Improved emoji detection regex - covers more symbols while staying simple
-  // This covers the vast majority of emoji use cases without complex Unicode parsing
   private static readonly EMOJI_REGEX =
     /(?:[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E6}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|[\u{1F900}-\u{1F9FF}]|[\u{1F018}-\u{1F270}]|[\u{238C}-\u{2454}]|[\u{20D0}-\u{20FF}]|[\u{FE0F}]|[\u{200D}]|[\u{2190}-\u{21FF}]|[\u{2000}-\u{206F}]|[\u{2070}-\u{209F}]|[\u{20A0}-\u{20CF}]|[\u{2100}-\u{214F}]|[\u{2150}-\u{218F}]|[\u{2460}-\u{24FF}]|[\u{2500}-\u{257F}]|[\u{2580}-\u{259F}]|[\u{25A0}-\u{25FF}]|[\u{2B00}-\u{2BFF}]|[\u{1F000}-\u{1F02F}]|[\u{1F0A0}-\u{1F0FF}]|[\u{1F100}-\u{1F1FF}]|[\u{1F200}-\u{1F2FF}]|[\u{1F300}-\u{1F5FF}]|[\u{1F600}-\u{1F64F}]|[\u{1F680}-\u{1F6FF}]|[\u{1F700}-\u{1F77F}]|[\u{1F780}-\u{1F7FF}]|[\u{1F800}-\u{1F8FF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{1FA70}-\u{1FAFF}])+/gu;
 
-  /**
-   * Simple and reliable emoji stripping with space handling
-   */
   private static stripEmojisAndFixSpaces(input: string): string {
-    return input
-      .replace(this.EMOJI_REGEX, ' ') // Replace emojis with space
-      .replace(/\s+/g, ' ') // Normalize multiple spaces
-      .trim(); // Clean up edges
+    return input.replace(this.EMOJI_REGEX, ' ').replace(/\s+/g, ' ').trim();
   }
 
-  /**
-   * Check if the current terminal supports emoji display.
-   *
-   * @returns True if emoji should be displayed, false otherwise
-   */
   static supportsEmoji(): boolean {
-    // Explicit disable via environment variables (check global standards first)
     if (process.env.NO_COLOR !== undefined || process.env.NO_EMOJI !== undefined) {
       return false;
     }
 
-    // Check devlogr-specific disable flags
     if (process.env.DEVLOGR_NO_COLOR || process.env.DEVLOGR_NO_EMOJI) {
       return false;
     }
 
-    // Explicit force enable for testing and CI environments
     if (process.env.DEVLOGR_FORCE_COLOR || process.env.FORCE_COLOR) {
       return true;
     }
 
-    // Check terminal capabilities - simplified logic
     const termProgram = process.env.TERM_PROGRAM || '';
     const colorTerm = process.env.COLORTERM || '';
     const term = process.env.TERM || '';
 
-    // Known emoji-supporting terminals
     const emojiTerminals = ['iTerm.app', 'Apple_Terminal', 'vscode', 'hyper', 'Windows Terminal'];
 
     if (emojiTerminals.includes(termProgram)) {
       return true;
     }
 
-    // Modern terminal indicators
     if (colorTerm === 'truecolor' || term.includes('256color')) {
       return true;
     }
 
-    // Platform defaults
     if (process.platform === 'darwin') {
-      return true; // macOS generally supports emoji well
+      return true;
     }
 
     if (process.platform === 'win32' && (process.env.WT_SESSION || process.env.WSLENV)) {
-      return true; // Windows Terminal or WSL
+      return true;
     }
 
-    // CI environments often support emojis
     if (this.isCI()) {
       return true;
     }
 
-    // Must be interactive to make sense
     return process.stdout.isTTY;
   }
 
-  /**
-   * Simple CI detection
-   */
   private static isCI(): boolean {
     return !!(
       process.env.CI ||
@@ -87,34 +61,15 @@ export class EmojiUtils {
     );
   }
 
-  /**
-   * Template literal function for conditional emoji display.
-   *
-   * @param strings - Template literal strings
-   * @param values - Template literal values
-   * @returns Text with emoji if supported, or text with emoji stripped
-   */
   static emoji(strings: TemplateStringsArray, ...values: unknown[]): string {
     const full = strings.reduce((acc, str, i) => acc + str + (values[i] ?? ''), '');
     return this.supportsEmoji() ? full : this.stripEmojisAndFixSpaces(full);
   }
 
-  /**
-   * Format text with conditional emoji support.
-   *
-   * @param text - Text that may contain emoji
-   * @returns Text with emoji if supported, or text with emoji stripped
-   */
   static format(text: string): string {
     return this.supportsEmoji() ? text : this.stripEmojisAndFixSpaces(text);
   }
 
-  /**
-   * Remove emoji from text regardless of terminal support.
-   *
-   * @param text - Text that may contain emoji
-   * @returns Text with all emoji removed
-   */
   static forceStripEmojis(text: string): string {
     return this.stripEmojisAndFixSpaces(text);
   }

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -1,14 +1,33 @@
+import { LogConfiguration } from '../config';
+
 /**
  * Emoji utilities for terminal output with automatic detection.
  */
 export class EmojiUtils {
+  // More precise emoji regex that excludes useful Unicode symbols like ✓, ✗, ℹ, →, etc.
   private static readonly EMOJI_REGEX =
-    /(?:[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E6}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|[\u{1F900}-\u{1F9FF}]|[\u{1F018}-\u{1F270}]|[\u{238C}-\u{2454}]|[\u{20D0}-\u{20FF}]|[\u{FE0F}]|[\u{200D}]|[\u{2190}-\u{21FF}]|[\u{2000}-\u{206F}]|[\u{2070}-\u{209F}]|[\u{20A0}-\u{20CF}]|[\u{2100}-\u{214F}]|[\u{2150}-\u{218F}]|[\u{2460}-\u{24FF}]|[\u{2500}-\u{257F}]|[\u{2580}-\u{259F}]|[\u{25A0}-\u{25FF}]|[\u{2B00}-\u{2BFF}]|[\u{1F000}-\u{1F02F}]|[\u{1F0A0}-\u{1F0FF}]|[\u{1F100}-\u{1F1FF}]|[\u{1F200}-\u{1F2FF}]|[\u{1F300}-\u{1F5FF}]|[\u{1F600}-\u{1F64F}]|[\u{1F680}-\u{1F6FF}]|[\u{1F700}-\u{1F77F}]|[\u{1F780}-\u{1F7FF}]|[\u{1F800}-\u{1F8FF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{1FA70}-\u{1FAFF}])+/gu;
+    /(?:[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E6}-\u{1F1FF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{1FA70}-\u{1FAFF}]|[\u{2640}-\u{2642}]|[\u{2695}]|[\u{26A0}]|[\u{26BD}]|[\u{26BE}]|[\u{26C4}]|[\u{26C5}]|[\u{26CE}]|[\u{26D4}]|[\u{26EA}]|[\u{26F2}]|[\u{26F3}]|[\u{26F5}]|[\u{26FA}]|[\u{26FD}]|[\u{2705}]|[\u{270A}]|[\u{270B}]|[\u{2728}]|[\u{274C}]|[\u{274E}]|[\u{2753}-\u{2755}]|[\u{2757}]|[\u{2795}-\u{2797}]|[\u{27B0}]|[\u{27BF}]|[\u{2B1B}]|[\u{2B1C}]|[\u{2B50}]|[\u{2B55}]|🚀|🎉|🌟|💡|⚡|🔥|❤️|💙|💚|💛|💜|🧡|🖤|🤍|🤎|💯|✨)+/gu;
 
+  // Preserve useful Unicode symbols while removing emojis and fixing spaces
   private static processEmojisAndFixSpaces(input: string): string {
-    return input.replace(this.EMOJI_REGEX, ' ').replace(/\s+/g, ' ').trim();
+    return input
+      .replace(this.EMOJI_REGEX, '') // Remove emojis completely
+      .replace(/\s+/g, ' ') // Normalize multiple spaces to single space
+      .trim(); // Remove leading/trailing spaces
   }
 
+  /**
+   * Check if emojis should be shown based on user configuration
+   */
+  static shouldShowEmojis(): boolean {
+    const config = LogConfiguration.getConfig();
+    return config.showEmojis;
+  }
+
+  /**
+   * Check if the terminal supports emoji characters (capability detection)
+   * Keeps all the existing CI adaptation and terminal detection logic
+   */
   static supportsEmoji(): boolean {
     if (process.env.NO_COLOR !== undefined || process.env.NO_EMOJI !== undefined) {
       return false;
@@ -63,11 +82,11 @@ export class EmojiUtils {
 
   static emoji(strings: TemplateStringsArray, ...values: unknown[]): string {
     const full = strings.reduce((acc, str, i) => acc + str + (values[i] ?? ''), '');
-    return this.supportsEmoji() ? full : this.processEmojisAndFixSpaces(full);
+    return this.shouldShowEmojis() ? full : this.processEmojisAndFixSpaces(full);
   }
 
   static format(text: string): string {
-    return this.supportsEmoji() ? text : this.processEmojisAndFixSpaces(text);
+    return this.shouldShowEmojis() ? text : this.processEmojisAndFixSpaces(text);
   }
 
   static forceStripEmojis(text: string): string {

--- a/src/utils/emoji.ts
+++ b/src/utils/emoji.ts
@@ -5,7 +5,7 @@ export class EmojiUtils {
   private static readonly EMOJI_REGEX =
     /(?:[\u{1F600}-\u{1F64F}]|[\u{1F300}-\u{1F5FF}]|[\u{1F680}-\u{1F6FF}]|[\u{1F1E6}-\u{1F1FF}]|[\u{2600}-\u{26FF}]|[\u{2700}-\u{27BF}]|[\u{1F900}-\u{1F9FF}]|[\u{1F018}-\u{1F270}]|[\u{238C}-\u{2454}]|[\u{20D0}-\u{20FF}]|[\u{FE0F}]|[\u{200D}]|[\u{2190}-\u{21FF}]|[\u{2000}-\u{206F}]|[\u{2070}-\u{209F}]|[\u{20A0}-\u{20CF}]|[\u{2100}-\u{214F}]|[\u{2150}-\u{218F}]|[\u{2460}-\u{24FF}]|[\u{2500}-\u{257F}]|[\u{2580}-\u{259F}]|[\u{25A0}-\u{25FF}]|[\u{2B00}-\u{2BFF}]|[\u{1F000}-\u{1F02F}]|[\u{1F0A0}-\u{1F0FF}]|[\u{1F100}-\u{1F1FF}]|[\u{1F200}-\u{1F2FF}]|[\u{1F300}-\u{1F5FF}]|[\u{1F600}-\u{1F64F}]|[\u{1F680}-\u{1F6FF}]|[\u{1F700}-\u{1F77F}]|[\u{1F780}-\u{1F7FF}]|[\u{1F800}-\u{1F8FF}]|[\u{1F900}-\u{1F9FF}]|[\u{1FA00}-\u{1FA6F}]|[\u{1FA70}-\u{1FAFF}])+/gu;
 
-  private static stripEmojisAndFixSpaces(input: string): string {
+  private static processEmojisAndFixSpaces(input: string): string {
     return input.replace(this.EMOJI_REGEX, ' ').replace(/\s+/g, ' ').trim();
   }
 
@@ -63,14 +63,14 @@ export class EmojiUtils {
 
   static emoji(strings: TemplateStringsArray, ...values: unknown[]): string {
     const full = strings.reduce((acc, str, i) => acc + str + (values[i] ?? ''), '');
-    return this.supportsEmoji() ? full : this.stripEmojisAndFixSpaces(full);
+    return this.supportsEmoji() ? full : this.processEmojisAndFixSpaces(full);
   }
 
   static format(text: string): string {
-    return this.supportsEmoji() ? text : this.stripEmojisAndFixSpaces(text);
+    return this.supportsEmoji() ? text : this.processEmojisAndFixSpaces(text);
   }
 
   static forceStripEmojis(text: string): string {
-    return this.stripEmojisAndFixSpaces(text);
+    return this.processEmojisAndFixSpaces(text);
   }
 }

--- a/src/utils/safe-string.ts
+++ b/src/utils/safe-string.ts
@@ -43,7 +43,7 @@ export class SafeStringUtils {
    * Creates a safe emoji string
    */
   static emoji(text: string): string {
-    return EmojiUtils.supportsEmoji() ? text : EmojiUtils.format(text);
+    return EmojiUtils.shouldShowEmojis() ? text : EmojiUtils.format(text);
   }
 
   /**

--- a/src/utils/spinner.ts
+++ b/src/utils/spinner.ts
@@ -249,22 +249,12 @@ export class SpinnerUtils {
         taskInfo.listr.tasks[0].title = text;
       }
 
-      // First, stop the listr2 renderer to prevent further updates
-      const renderer = getListrRenderer(taskInfo.listr);
-      if (renderer?.end) {
-        renderer.end();
-      }
-
       // Clear the spinner display to prevent artifacts
       if (taskInfo.spinner?.clear) taskInfo.spinner.clear();
       if (taskInfo.spinner?.stop) taskInfo.spinner.stop();
 
+      // Mark the task as completed - Listr2 will handle the final rendering
       if (taskInfo.resolver) taskInfo.resolver();
-
-      // Clear the display to ensure clean state
-      if (process.stdout.isTTY) {
-        process.stdout.write('\u001b[2K\r'); // Clear current line and move cursor to beginning
-      }
 
       return text;
     }
@@ -285,23 +275,13 @@ export class SpinnerUtils {
         taskInfo.listr.tasks[0].title = text;
       }
 
-      // First, stop the listr2 renderer to prevent further updates
-      const renderer = getListrRenderer(taskInfo.listr);
-      if (renderer?.end) {
-        renderer.end();
-      }
-
       // Clear the spinner display to prevent artifacts
       if (taskInfo.spinner?.clear) taskInfo.spinner.clear();
       if (taskInfo.spinner?.stop) taskInfo.spinner.stop();
 
+      // Mark the task as failed - Listr2 will handle the final rendering
       if (taskInfo.rejecter) {
         taskInfo.rejecter(new Error(text || 'Task failed'));
-      }
-
-      // Clear the display to ensure clean state
-      if (process.stdout.isTTY) {
-        process.stdout.write('\u001b[2K\r'); // Clear current line and move cursor to beginning
       }
 
       return text;

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -210,6 +210,7 @@ export class TerminalUtils {
     showPrefix: boolean;
     showTimestamp: boolean;
     showIcons: boolean;
+    showEmojis: boolean;
     useColors: boolean;
     supportsEmoji: boolean;
   } {
@@ -220,6 +221,7 @@ export class TerminalUtils {
         showPrefix: false,
         showTimestamp: false,
         showIcons: true,
+        showEmojis: true, // Default to showing emojis when not in CI
         useColors: this.supportsColor(), // Keep dynamic color detection
         supportsEmoji: this.supportsEmoji(), // Keep dynamic emoji detection
       };
@@ -231,6 +233,7 @@ export class TerminalUtils {
       showPrefix: isCI,
       showTimestamp: isCI,
       showIcons: !isCI, // Disable icons in CI for better compatibility
+      showEmojis: !isCI, // Disable emojis in CI for better compatibility
       useColors: this.supportsColor(), // Keep dynamic color detection
       supportsEmoji: this.supportsEmoji(), // Keep dynamic emoji detection
     };

--- a/src/utils/terminal.ts
+++ b/src/utils/terminal.ts
@@ -245,14 +245,14 @@ export class TerminalUtils {
    * @returns True if emoji can be displayed, false otherwise
    */
   static supportsEmoji(): boolean {
-    // Check for explicit disable flags
-    if (process.env.NO_EMOJI !== undefined || process.env.DEVLOGR_NO_EMOJI === 'true') {
+    // Check for explicit disable flags (global standards)
+    if (process.env.NO_EMOJI !== undefined) {
       return false;
     }
 
-    // If explicitly enabled
-    if (process.env.DEVLOGR_EMOJI === 'true') {
-      return true;
+    // Check for devlogr-specific show emoji setting
+    if (process.env.DEVLOGR_SHOW_EMOJI !== undefined) {
+      return process.env.DEVLOGR_SHOW_EMOJI === 'true' || process.env.DEVLOGR_SHOW_EMOJI === '1';
     }
 
     // CI environments: let dynamic detection decide

--- a/tests/config/themes.test.ts
+++ b/tests/config/themes.test.ts
@@ -1,8 +1,14 @@
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { LogLevel } from '../../src/types';
 import { Logger } from '../../src/logger';
+import { setupTestEnvironment } from '../helpers/test-environment';
 
 describe('Logger Themes and Configuration', () => {
+  beforeEach(() => {
+    // Setup secure test environment with default non-CI behavior
+    setupTestEnvironment();
+  });
+
   describe('LogLevel enum', () => {
     it('should have all required log levels', () => {
       expect(LogLevel.DEBUG).toBeDefined();

--- a/tests/core/ci-detection.test.ts
+++ b/tests/core/ci-detection.test.ts
@@ -260,4 +260,3 @@ describe('CI Detection', () => {
     });
   });
 });
- 

--- a/tests/core/ci-detection.test.ts
+++ b/tests/core/ci-detection.test.ts
@@ -143,13 +143,13 @@ describe('CI Detection', () => {
       expect(TerminalUtils.supportsEmoji()).toBe(false);
     });
 
-    it('should not support emoji when DEVLOGR_NO_EMOJI is set', () => {
-      process.env = { DEVLOGR_NO_EMOJI: 'true' };
+    it('should not support emoji when DEVLOGR_SHOW_EMOJI is false', () => {
+      process.env = { DEVLOGR_SHOW_EMOJI: 'false' };
       expect(TerminalUtils.supportsEmoji()).toBe(false);
     });
 
     it('should support emoji when explicitly enabled', () => {
-      process.env = { DEVLOGR_EMOJI: 'true' };
+      process.env = { DEVLOGR_SHOW_EMOJI: 'true' };
       expect(TerminalUtils.supportsEmoji()).toBe(true);
     });
 
@@ -174,7 +174,7 @@ describe('CI Detection', () => {
         CI: 'true',
         DEVLOGR_SHOW_PREFIX: 'false',
         DEVLOGR_SHOW_TIMESTAMP: 'false',
-        DEVLOGR_NO_ICONS: 'false',
+        DEVLOGR_SHOW_ICONS: 'true',
       };
       const config = LogConfiguration.getConfig();
 
@@ -250,12 +250,12 @@ describe('CI Detection', () => {
     });
 
     it('should prioritize explicit disable over CI detection', () => {
-      process.env = { CI: 'true', DEVLOGR_NO_EMOJI: 'true' };
+      process.env = { CI: 'true', DEVLOGR_SHOW_EMOJI: 'false' };
       expect(TerminalUtils.supportsEmoji()).toBe(false);
     });
 
     it('should prioritize explicit enable over CI detection', () => {
-      process.env = { CI: 'true', DEVLOGR_EMOJI: 'true' };
+      process.env = { CI: 'true', DEVLOGR_SHOW_EMOJI: 'true' };
       expect(TerminalUtils.supportsEmoji()).toBe(true);
     });
   });

--- a/tests/core/ci-detection.test.ts
+++ b/tests/core/ci-detection.test.ts
@@ -260,3 +260,4 @@ describe('CI Detection', () => {
     });
   });
 });
+ 

--- a/tests/core/environment.test.ts
+++ b/tests/core/environment.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Logger, createLogger } from '../../src/logger';
-import { LogLevel } from '../../src/types';
 import { LogConfiguration } from '../../src/config';
 
 describe('Logger Environment Variables', () => {
@@ -380,6 +379,7 @@ describe('Logger Environment Variables', () => {
 
       const loggedMessage = consoleSpy.mock.calls[0][0] as string;
       // Strip ANSI color codes for testing
+      // eslint-disable-next-line no-control-regex
       const cleanMessage = loggedMessage.replace(/\u001b\[[0-9;]*m/g, '');
 
       // When icons are disabled, there should be no extra spacing before the log level

--- a/tests/core/environment.test.ts
+++ b/tests/core/environment.test.ts
@@ -2,6 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { Logger, createLogger } from '../../src/logger';
 import { LogConfiguration } from '../../src/config';
 
+import { setupTestEnvironment } from '../helpers/test-environment';
+
 describe('Logger Environment Variables', () => {
   let originalEnv: Record<string, string | undefined>;
 
@@ -21,10 +23,8 @@ describe('Logger Environment Variables', () => {
       DEVLOGR_NO_ICONS: process.env.DEVLOGR_NO_ICONS,
     };
 
-    // Clear environment variables for clean slate
-    Object.keys(originalEnv).forEach(key => {
-      delete process.env[key];
-    });
+    // Setup secure test environment with default non-CI behavior
+    setupTestEnvironment();
 
     // Reset logger level
     Logger.resetLevel();

--- a/tests/core/environment.test.ts
+++ b/tests/core/environment.test.ts
@@ -20,7 +20,7 @@ describe('Logger Environment Variables', () => {
       NO_EMOJI: process.env.NO_EMOJI,
       DEVLOGR_NO_EMOJI: process.env.DEVLOGR_NO_EMOJI,
       DEVLOGR_SHOW_TIMESTAMP: process.env.DEVLOGR_SHOW_TIMESTAMP,
-      DEVLOGR_NO_ICONS: process.env.DEVLOGR_NO_ICONS,
+      DEVLOGR_SHOW_ICONS: process.env.DEVLOGR_SHOW_ICONS,
     };
 
     // Setup secure test environment with default non-CI behavior
@@ -321,32 +321,32 @@ describe('Logger Environment Variables', () => {
   });
 
   describe('Icon Environment Variables', () => {
-    it('should respect DEVLOGR_NO_ICONS environment variable', () => {
-      process.env.DEVLOGR_NO_ICONS = 'true';
+    it('should respect DEVLOGR_SHOW_ICONS=false environment variable', () => {
+      process.env.DEVLOGR_SHOW_ICONS = 'false';
       const config = LogConfiguration.getConfig();
       expect(config.showIcons).toBe(false);
     });
 
-    it('should respect DEVLOGR_NO_ICONS=1 environment variable', () => {
-      process.env.DEVLOGR_NO_ICONS = '1';
-      const config = LogConfiguration.getConfig();
-      expect(config.showIcons).toBe(false);
-    });
-
-    it('should show icons by default when DEVLOGR_NO_ICONS is not set', () => {
-      delete process.env.DEVLOGR_NO_ICONS;
+    it('should respect DEVLOGR_SHOW_ICONS=true environment variable', () => {
+      process.env.DEVLOGR_SHOW_ICONS = 'true';
       const config = LogConfiguration.getConfig();
       expect(config.showIcons).toBe(true);
     });
 
-    it('should show icons when DEVLOGR_NO_ICONS is set to false', () => {
-      process.env.DEVLOGR_NO_ICONS = 'false';
+    it('should respect DEVLOGR_SHOW_ICONS=1 environment variable', () => {
+      process.env.DEVLOGR_SHOW_ICONS = '1';
       const config = LogConfiguration.getConfig();
       expect(config.showIcons).toBe(true);
     });
 
-    it('should hide icons in log output when DEVLOGR_NO_ICONS=true', () => {
-      process.env.DEVLOGR_NO_ICONS = 'true';
+    it('should show icons by default when DEVLOGR_SHOW_ICONS is not set', () => {
+      delete process.env.DEVLOGR_SHOW_ICONS;
+      const config = LogConfiguration.getConfig();
+      expect(config.showIcons).toBe(true);
+    });
+
+    it('should hide icons in log output when DEVLOGR_SHOW_ICONS=false', () => {
+      process.env.DEVLOGR_SHOW_ICONS = 'false';
       const logger = createLogger('TEST');
 
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -366,8 +366,8 @@ describe('Logger Environment Variables', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should remove icon padding when DEVLOGR_NO_ICONS=true and DEVLOGR_SHOW_PREFIX=true', () => {
-      process.env.DEVLOGR_NO_ICONS = 'true';
+    it('should remove icon padding when DEVLOGR_SHOW_ICONS=false and DEVLOGR_SHOW_PREFIX=true', () => {
+      process.env.DEVLOGR_SHOW_ICONS = 'false';
       process.env.DEVLOGR_SHOW_PREFIX = 'true';
       const logger = createLogger('TEST');
 
@@ -411,8 +411,8 @@ describe('Logger Environment Variables', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should respect DEVLOGR_NO_EMOJI environment variable', () => {
-      process.env.DEVLOGR_NO_EMOJI = '1';
+    it('should respect DEVLOGR_SHOW_EMOJI=false environment variable', () => {
+      process.env.DEVLOGR_SHOW_EMOJI = 'false';
       const logger = createLogger('TEST');
 
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/tests/core/environment.test.ts
+++ b/tests/core/environment.test.ts
@@ -267,10 +267,10 @@ describe('Logger Environment Variables', () => {
         // Should have made 3 console.log calls
         expect(consoleSpy).toHaveBeenCalledTimes(3);
 
-        // Check calls: spacer (no args), separator (dashes), separator with title
+        // Check calls: spacer (no args), separator (fixed length), separator with title (fixed format)
         expect(consoleSpy.mock.calls[0]).toEqual([]); // spacer() calls console.log() with no args
-        expect(consoleSpy.mock.calls[1][0]).toMatch(/^-+$/);
-        expect(consoleSpy.mock.calls[2][0]).toMatch(/^-+ Title -+$/);
+        expect(consoleSpy.mock.calls[1][0]).toMatch(/^[─-]{60}$/); // Fixed length separator
+        expect(consoleSpy.mock.calls[2][0]).toMatch(/^[─-]{2} Title [─-]+$/); // Fixed format with title
 
         consoleSpy.mockRestore();
       } finally {

--- a/tests/core/global-standards.test.ts
+++ b/tests/core/global-standards.test.ts
@@ -15,7 +15,7 @@ describe('Global Environment Variable Standards', () => {
       'NO_UNICODE',
       'FORCE_COLOR',
       'DEVLOGR_NO_COLOR',
-      'DEVLOGR_NO_EMOJI',
+      'DEVLOGR_SHOW_EMOJI',
       'DEVLOGR_NO_UNICODE',
       'DEVLOGR_FORCE_COLOR',
       'DEVLOGR_UNICODE',
@@ -80,7 +80,7 @@ describe('Global Environment Variable Standards', () => {
 
     it('should take precedence over devlogr-specific emoji settings', () => {
       process.env.NO_EMOJI = '1';
-      process.env.DEVLOGR_NO_EMOJI = 'false'; // This shouldn't matter
+      process.env.DEVLOGR_SHOW_EMOJI = 'true'; // This shouldn't matter
       expect(EmojiUtils.supportsEmoji()).toBe(false);
     });
 
@@ -155,7 +155,7 @@ describe('Global Environment Variable Standards', () => {
       expect(TerminalUtils.supportsColor()).toBe(false);
 
       // Test NO_EMOJI precedence
-      process.env.DEVLOGR_NO_EMOJI = 'false';
+      process.env.DEVLOGR_SHOW_EMOJI = 'true';
       process.env.NO_EMOJI = '1';
       expect(EmojiUtils.supportsEmoji()).toBe(false);
 
@@ -178,7 +178,7 @@ describe('Global Environment Variable Standards', () => {
     it('should work correctly with mixed global and devlogr settings', () => {
       // Global disables color, devlogr enables emoji
       process.env.NO_COLOR = '1';
-      process.env.DEVLOGR_NO_EMOJI = 'false';
+      process.env.DEVLOGR_SHOW_EMOJI = 'true';
 
       expect(TerminalUtils.supportsColor()).toBe(false);
       expect(EmojiUtils.supportsEmoji()).toBe(false); // Should be false due to NO_COLOR

--- a/tests/core/integration.test.ts
+++ b/tests/core/integration.test.ts
@@ -1,9 +1,12 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Logger } from '../../src/logger';
 import { LogLevel } from '../../src/types';
+import { setupTestEnvironment } from '../helpers/test-environment';
 
 describe('Logger Integration', () => {
   beforeEach(() => {
+    // Setup secure test environment with default non-CI behavior
+    setupTestEnvironment();
     Logger.resetLevel();
   });
 

--- a/tests/format/centralized-formatting.test.ts
+++ b/tests/format/centralized-formatting.test.ts
@@ -147,7 +147,7 @@ describe('Centralized Formatting', () => {
         theme: { symbol: '🚀', label: 'ROCKET', color: (text: string) => text },
         message: 'Message with 🎉 emojis',
         args: ['More 🌟 emojis'],
-        stripEmojis: true,
+        showEmojis: false,
         includeLevel: false,
         includePrefix: false,
       });
@@ -274,7 +274,7 @@ describe('Centralized Formatting', () => {
         showTimestamp: true,
         useColors: true,
         timestampFormat: TimestampFormat.TIME,
-        stripEmojis: false,
+        showEmojis: true,
         includeLevel: true,
         includePrefix: true,
       });

--- a/tests/format/centralized-formatting.test.ts
+++ b/tests/format/centralized-formatting.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { MessageFormatter } from '../../src/formatters';
+import { StringUtils } from '../../src/utils';
+import { TimestampFormat } from '../../src/types';
+
+import { setupTestEnvironment } from '../helpers/test-environment';
+
+describe('Centralized Formatting', () => {
+  beforeEach(() => {
+    setupTestEnvironment();
+  });
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe('StringUtils.formatTime', () => {
+    beforeEach(() => {
+      // Mock Date to have consistent timestamps in tests
+      const mockDate = new Date('2023-01-15T14:30:45.123Z');
+      vi.spyOn(global, 'Date').mockImplementation(() => mockDate as Date);
+      // Mock the time methods
+      vi.spyOn(mockDate, 'toTimeString').mockReturnValue('14:30:45 GMT+0000 (UTC)');
+      vi.spyOn(mockDate, 'toISOString').mockReturnValue('2023-01-15T14:30:45.123Z');
+    });
+
+    it('should format time in HH:MM:SS format by default', () => {
+      const result = StringUtils.formatTime();
+      expect(result).toBe('14:30:45');
+    });
+
+    it('should format time in HH:MM:SS format when TimestampFormat.TIME is specified', () => {
+      const result = StringUtils.formatTime(TimestampFormat.TIME);
+      expect(result).toBe('14:30:45');
+    });
+
+    it('should format time in ISO format when TimestampFormat.ISO is specified', () => {
+      const result = StringUtils.formatTime(TimestampFormat.ISO);
+      expect(result).toBe('2023-01-15T14:30:45.123Z');
+    });
+
+    it('should handle time extraction correctly for TIME format', () => {
+      const result = StringUtils.formatTime(TimestampFormat.TIME);
+      // Should extract only the time portion (HH:MM:SS)
+      expect(result).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+      expect(result).toBe('14:30:45');
+    });
+
+    it('should provide full ISO string for ISO format', () => {
+      const result = StringUtils.formatTime(TimestampFormat.ISO);
+      expect(result).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+      expect(result).toBe('2023-01-15T14:30:45.123Z');
+    });
+
+    it('should work with real Date object', () => {
+      vi.restoreAllMocks(); // Remove mocks to test with real Date
+
+      const result = StringUtils.formatTime(TimestampFormat.TIME);
+      expect(result).toMatch(/^\d{2}:\d{2}:\d{2}$/);
+
+      const isoResult = StringUtils.formatTime(TimestampFormat.ISO);
+      expect(isoResult).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/);
+    });
+  });
+
+  describe('MessageFormatter.format - Universal Formatter', () => {
+    const mockTheme = {
+      symbol: '✓',
+      label: 'SUCCESS',
+      color: (text: string) => `colored(${text})`,
+    };
+
+    it('should format basic message with minimal options', () => {
+      const result = MessageFormatter.format({
+        message: 'Test message',
+      });
+
+      expect(result).toBe('Test message');
+    });
+
+    it('should format message with symbol only', () => {
+      const result = MessageFormatter.format({
+        theme: mockTheme,
+        message: 'Success message',
+        includeLevel: false,
+        includePrefix: false,
+      });
+
+      expect(result).toBe('✓ Success message');
+    });
+
+    it('should format message with colors when enabled', () => {
+      const result = MessageFormatter.format({
+        theme: mockTheme,
+        message: 'Colored message',
+        useColors: true,
+        includeLevel: false,
+        includePrefix: false,
+      });
+
+      expect(result).toBe('colored(✓) Colored message');
+    });
+
+    it('should format complete message with all components', () => {
+      // Mock formatTime to have predictable output
+      vi.spyOn(StringUtils, 'formatTime').mockReturnValue('12:34:56');
+
+      const result = MessageFormatter.format({
+        level: 'success',
+        theme: mockTheme,
+        message: 'Complete message',
+        prefix: 'app',
+        maxPrefixLength: 10,
+        showTimestamp: true,
+        useColors: false,
+        includeLevel: true,
+        includePrefix: true,
+      });
+
+      expect(result).toContain('[12:34:56]');
+      expect(result).toContain('✓');
+      expect(result).toContain('SUCCESS');
+      expect(result).toContain('[app]');
+      expect(result).toContain('Complete message');
+    });
+
+    it('should handle arguments formatting', () => {
+      const result = MessageFormatter.format({
+        theme: mockTheme,
+        message: 'Message with args',
+        args: ['arg1', { key: 'value' }],
+        includeLevel: false,
+        includePrefix: false,
+      });
+
+      expect(result).toContain('Message with args');
+      expect(result).toContain('arg1');
+      expect(result).toContain('key');
+      expect(result).toContain('value');
+    });
+
+    it('should strip emojis when requested', () => {
+      const result = MessageFormatter.format({
+        theme: { symbol: '🚀', label: 'ROCKET', color: (text: string) => text },
+        message: 'Message with 🎉 emojis',
+        args: ['More 🌟 emojis'],
+        stripEmojis: true,
+        includeLevel: false,
+        includePrefix: false,
+      });
+
+      // Symbol emoji stripping is not implemented in the minimal format path
+      // This is expected behavior - symbols are themed elements that remain consistent
+      expect(result).toContain('🚀'); // Symbol remains
+      expect(result).not.toContain('🎉'); // Message emojis stripped
+      expect(result).not.toContain('🌟'); // Arg emojis stripped
+      expect(result).toContain('Message with emojis'); // Spaces normalized
+      expect(result).toContain('More emojis'); // Spaces normalized
+    });
+
+    it('should handle timestamp formats correctly', () => {
+      vi.spyOn(StringUtils, 'formatTime').mockImplementation(format => {
+        return format === TimestampFormat.ISO ? '2023-01-15T12:34:56.789Z' : '12:34:56';
+      });
+
+      const timeResult = MessageFormatter.format({
+        message: 'Time format',
+        showTimestamp: true,
+        timestampFormat: TimestampFormat.TIME,
+      });
+
+      const isoResult = MessageFormatter.format({
+        message: 'ISO format',
+        showTimestamp: true,
+        timestampFormat: TimestampFormat.ISO,
+      });
+
+      expect(timeResult).toContain('[12:34:56]');
+      expect(isoResult).toContain('[2023-01-15T12:34:56.789Z]');
+    });
+
+    it('should handle prefix alignment correctly', () => {
+      // Test prefix alignment with timestamp to trigger the spacing logic
+      vi.spyOn(StringUtils, 'formatTime').mockReturnValue('12:34:56');
+
+      const shortPrefix = MessageFormatter.format({
+        prefix: 'app',
+        maxPrefixLength: 15,
+        message: 'Short prefix',
+        showTimestamp: true,
+        includeLevel: false,
+        includePrefix: true,
+      });
+
+      const longPrefix = MessageFormatter.format({
+        prefix: 'very-long-service-name',
+        maxPrefixLength: 15,
+        message: 'Long prefix',
+        showTimestamp: true,
+        includeLevel: false,
+        includePrefix: true,
+      });
+
+      expect(shortPrefix).toContain('[app]');
+      expect(longPrefix).toContain('[very-long-service-name]');
+
+      // Both should have timestamp and proper prefix alignment
+      expect(shortPrefix).toContain('[12:34:56]');
+      expect(longPrefix).toContain('[12:34:56]');
+
+      // The short prefix should have more leading spaces for alignment
+      // Pattern: [timestamp] {spaces}[prefix] message
+      const shortMatch = shortPrefix.match(/\[12:34:56\](\s+)\[app\]/);
+      const longMatch = longPrefix.match(/\[12:34:56\](\s+)\[very-long-service-name\]/);
+
+      expect(shortMatch).toBeTruthy();
+      expect(longMatch).toBeTruthy();
+
+      if (shortMatch && longMatch) {
+        const shortSpaces = shortMatch[1].length;
+        const longSpaces = longMatch[1].length;
+        expect(shortSpaces).toBeGreaterThan(longSpaces);
+      }
+    });
+
+    it('should handle minimal format for spinners and simple messages', () => {
+      const result = MessageFormatter.format({
+        theme: { symbol: '⠋', label: 'SPINNER', color: (text: string) => text },
+        message: 'Loading...',
+        includeLevel: false,
+        includePrefix: false,
+        showTimestamp: false,
+      });
+
+      expect(result).toBe('⠋ Loading...');
+      expect(result).not.toContain('SPINNER');
+      expect(result).not.toContain('[');
+    });
+
+    it('should handle empty messages gracefully', () => {
+      const result = MessageFormatter.format({
+        theme: mockTheme,
+        message: '',
+        includeLevel: false,
+        includePrefix: false,
+      });
+
+      expect(result).toBe('✓'); // trim() removes trailing space from empty message
+    });
+
+    it('should handle missing theme gracefully', () => {
+      const result = MessageFormatter.format({
+        message: 'No theme message',
+        includeLevel: false,
+        includePrefix: false,
+      });
+
+      expect(result).toBe('No theme message');
+    });
+
+    it('should handle complex combinations correctly', () => {
+      vi.spyOn(StringUtils, 'formatTime').mockReturnValue('09:15:30');
+
+      const result = MessageFormatter.format({
+        level: 'error',
+        theme: { symbol: '✖', label: 'ERROR', color: (text: string) => `red(${text})` },
+        message: 'Critical error occurred',
+        args: [{ code: 500, details: 'Server error' }],
+        prefix: 'api-server',
+        maxPrefixLength: 20,
+        showTimestamp: true,
+        useColors: true,
+        timestampFormat: TimestampFormat.TIME,
+        stripEmojis: false,
+        includeLevel: true,
+        includePrefix: true,
+      });
+
+      expect(result).toContain('[09:15:30]');
+      expect(result).toContain('red(✖)');
+      expect(result).toContain('ERROR');
+      expect(result).toContain('[api-server]');
+      expect(result).toContain('Critical error occurred');
+      expect(result).toContain('code');
+      expect(result).toContain('500');
+    });
+
+    it('should prioritize environment timestamp over CI when explicitly set', () => {
+      vi.spyOn(StringUtils, 'formatTime').mockReturnValue('15:45:30');
+
+      // Test that explicit showTimestamp takes precedence
+      const withTimestamp = MessageFormatter.format({
+        message: 'Explicit timestamp',
+        showTimestamp: true,
+      });
+
+      const withoutTimestamp = MessageFormatter.format({
+        message: 'No timestamp',
+        showTimestamp: false,
+      });
+
+      expect(withTimestamp).toContain('[15:45:30]');
+      expect(withoutTimestamp).not.toContain('[15:45:30]');
+    });
+  });
+
+  describe('Format Consistency', () => {
+    it('should produce consistent output across multiple calls', () => {
+      vi.spyOn(StringUtils, 'formatTime').mockReturnValue('10:20:30');
+
+      const options = {
+        level: 'info',
+        theme: { symbol: 'ℹ', label: 'INFO', color: (text: string) => text },
+        message: 'Consistent message',
+        prefix: 'test',
+        maxPrefixLength: 10,
+        showTimestamp: true,
+        useColors: false,
+        includeLevel: true,
+        includePrefix: true,
+      };
+
+      const result1 = MessageFormatter.format(options);
+      const result2 = MessageFormatter.format(options);
+      const result3 = MessageFormatter.format(options);
+
+      expect(result1).toBe(result2);
+      expect(result2).toBe(result3);
+    });
+
+    it('should maintain correct component order', () => {
+      vi.spyOn(StringUtils, 'formatTime').mockReturnValue('11:22:33');
+      setupTestEnvironment(true, true);
+
+      const result = MessageFormatter.format({
+        level: 'warn',
+        theme: { symbol: '⚠', label: 'WARN', color: (text: string) => text },
+        message: 'Order test',
+        prefix: 'order',
+        maxPrefixLength: 10,
+        showTimestamp: true,
+        useColors: false,
+        includeLevel: true,
+        includePrefix: true,
+      });
+
+      // Should follow order: [timestamp] LEVEL [prefix] symbol message
+      expect(result).toMatch(/\[11:22:33\] WARN\s+\[order\] ⚠ Order test/);
+      expect(result).toContain('[11:22:33]');
+      expect(result).toContain('WARN   '); // Level is padded to 7 chars
+      expect(result).toContain('[order]');
+      expect(result).toContain('⚠');
+      expect(result).toContain('Order test');
+    });
+  });
+});

--- a/tests/format/plain-alignment.test.ts
+++ b/tests/format/plain-alignment.test.ts
@@ -49,7 +49,7 @@ describe('PLAIN Level Alignment', () => {
   });
 
   it('should align PLAIN level with other levels when icons are disabled', () => {
-    setupTestEnvironment(false, true, true); // showTimestamp=false, showPrefix=true, noIcons=true
+    setupTestEnvironment(false, true, true); // showTimestamp=false, showPrefix=true, hideIcons=true
     const logger = createLogger('TEST');
 
     logger.task('This is a TASK message');

--- a/tests/format/timestamp.test.ts
+++ b/tests/format/timestamp.test.ts
@@ -1,15 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createLogger, Logger } from '../../src/logger';
-import { LogLevel, TimestampFormat } from '../../src/types';
-import { SpinnerUtils } from '../../src/utils';
+import { TimestampFormat } from '../../src/types';
 import { LogConfiguration } from '../../src/config';
 
 describe('Logger Timestamp Behavior', () => {
   let logger: Logger;
-  let consoleSpy: any;
-  let consoleErrorSpy: any;
-  let consoleWarnSpy: any;
-  let consoleDebugSpy: any;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
   const originalEnv = process.env;
 
   beforeEach(() => {
@@ -17,9 +13,9 @@ describe('Logger Timestamp Behavior', () => {
 
     // Set up console spies
     consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
-    consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
-    consoleWarnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
-    consoleDebugSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'debug').mockImplementation(() => {});
 
     // Reset logger level
     Logger.resetLevel();
@@ -277,7 +273,7 @@ describe('Logger Timestamp Behavior', () => {
       // Check if any call contains the success message with ISO timestamp
       const calls = consoleSpy.mock.calls;
       const successCall = calls.find(
-        (call: any[]) => call[0] && typeof call[0] === 'string' && call[0].includes('Done!')
+        (call: unknown[]) => call[0] && typeof call[0] === 'string' && call[0].includes('Done!')
       );
 
       expect(successCall).toBeDefined();

--- a/tests/helpers/ansi-utils.ts
+++ b/tests/helpers/ansi-utils.ts
@@ -1,0 +1,23 @@
+/**
+ * ANSI escape sequence utilities for tests
+ */
+
+// ANSI escape sequence regex for removing color codes in tests
+export const ANSI_ESCAPE_REGEX = new RegExp('\u001b' + '\\[[0-9;]*m', 'g');
+
+// ANSI color detection regex for testing color presence
+export const ANSI_COLOR_REGEX = new RegExp('\u001b' + '\\[');
+
+/**
+ * Remove ANSI escape sequences from text
+ */
+export function stripAnsiColors(text: string): string {
+  return text.replace(ANSI_ESCAPE_REGEX, '');
+}
+
+/**
+ * Check if text contains ANSI color codes
+ */
+export function hasAnsiColors(text: string): boolean {
+  return ANSI_COLOR_REGEX.test(text);
+}

--- a/tests/helpers/test-environment.ts
+++ b/tests/helpers/test-environment.ts
@@ -17,7 +17,7 @@
 export function setupTestEnvironment(
   showTimestamp = false,
   showPrefix = false,
-  noIcons = false,
+  hideIcons = false,
   useColors = true,
   logLevel?: string,
   outputJson = false
@@ -25,7 +25,7 @@ export function setupTestEnvironment(
   // Clear all DevLogr environment variables
   delete process.env.DEVLOGR_SHOW_TIMESTAMP;
   delete process.env.DEVLOGR_SHOW_PREFIX;
-  delete process.env.DEVLOGR_NO_ICONS;
+  delete process.env.DEVLOGR_SHOW_ICONS;
   delete process.env.DEVLOGR_NO_COLOR;
   delete process.env.NO_COLOR;
   delete process.env.DEVLOGR_LOG_LEVEL;
@@ -38,7 +38,7 @@ export function setupTestEnvironment(
   // Apply test-specific environment configuration
   if (showTimestamp) process.env.DEVLOGR_SHOW_TIMESTAMP = 'true';
   if (showPrefix) process.env.DEVLOGR_SHOW_PREFIX = 'true';
-  if (noIcons) process.env.DEVLOGR_NO_ICONS = 'true';
+  if (hideIcons) process.env.DEVLOGR_SHOW_ICONS = 'false';
   if (useColors === false) process.env.NO_COLOR = '1';
   if (logLevel) process.env.DEVLOGR_LOG_LEVEL = logLevel;
   if (outputJson) process.env.DEVLOGR_OUTPUT_JSON = 'true';

--- a/tests/helpers/test-environment.ts
+++ b/tests/helpers/test-environment.ts
@@ -1,0 +1,45 @@
+/**
+ * Test Environment Helper
+ *
+ * Provides a centralized way to set up consistent test environments
+ * across all DevLogr test files. Ensures proper environment variable
+ * isolation and prevents test pollution.
+ */
+
+/**
+ * Sets up a clean, isolated test environment for DevLogr tests.
+ *
+ * This function:
+ * 1. Clears all DevLogr environment variables
+ * 2. Sets DEVLOGR_DISABLE_CI_DETECTION=true for consistent behavior
+ * 3. Applies the specified test configuration
+ */
+export function setupTestEnvironment(
+  showTimestamp = false,
+  showPrefix = false,
+  noIcons = false,
+  useColors = true,
+  logLevel?: string,
+  outputJson = false
+): void {
+  // Clear all DevLogr environment variables
+  delete process.env.DEVLOGR_SHOW_TIMESTAMP;
+  delete process.env.DEVLOGR_SHOW_PREFIX;
+  delete process.env.DEVLOGR_NO_ICONS;
+  delete process.env.DEVLOGR_NO_COLOR;
+  delete process.env.NO_COLOR;
+  delete process.env.DEVLOGR_LOG_LEVEL;
+  delete process.env.DEVLOGR_OUTPUT_JSON;
+  delete process.env.DEVLOGR_DISABLE_CI_DETECTION;
+
+  // Set default non-CI behavior for consistent test results
+  process.env.DEVLOGR_DISABLE_CI_DETECTION = 'true';
+
+  // Apply test-specific environment configuration
+  if (showTimestamp) process.env.DEVLOGR_SHOW_TIMESTAMP = 'true';
+  if (showPrefix) process.env.DEVLOGR_SHOW_PREFIX = 'true';
+  if (noIcons) process.env.DEVLOGR_NO_ICONS = 'true';
+  if (useColors === false) process.env.NO_COLOR = '1';
+  if (logLevel) process.env.DEVLOGR_LOG_LEVEL = logLevel;
+  if (outputJson) process.env.DEVLOGR_OUTPUT_JSON = 'true';
+}

--- a/tests/spinner/level-policy-consistency.test.ts
+++ b/tests/spinner/level-policy-consistency.test.ts
@@ -1,0 +1,286 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { Logger } from '../../src/logger';
+import { LogConfiguration } from '../../src/config';
+
+describe('Spinner Level Policy Consistency', () => {
+  let originalEnv: Record<string, string | undefined>;
+  let mockConsoleLog: ReturnType<typeof vi.fn>;
+  let mockConsoleError: ReturnType<typeof vi.fn>;
+  let mockConsoleWarn: ReturnType<typeof vi.fn>;
+  let mockStdoutWrite: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    // Save original environment
+    originalEnv = { ...process.env };
+
+    // Mock all console methods and stdout
+    mockConsoleLog = vi.fn();
+    mockConsoleError = vi.fn();
+    mockConsoleWarn = vi.fn();
+    mockStdoutWrite = vi.fn();
+
+    vi.spyOn(console, 'log').mockImplementation(mockConsoleLog);
+    vi.spyOn(console, 'error').mockImplementation(mockConsoleError);
+    vi.spyOn(console, 'warn').mockImplementation(mockConsoleWarn);
+    vi.spyOn(process.stdout, 'write').mockImplementation(mockStdoutWrite);
+
+    // Force non-TTY to avoid spinner animations in tests
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: false,
+      configurable: true,
+    });
+
+    // Clear configuration cache
+    LogConfiguration.clearCache?.();
+  });
+
+  afterEach(() => {
+    // Restore environment
+    process.env = originalEnv;
+    vi.restoreAllMocks();
+    LogConfiguration.clearCache?.();
+  });
+
+  // Helper to get all console output
+  const getAllConsoleOutput = () => {
+    const allOutput = [
+      ...mockConsoleLog.mock.calls.map(call => call[0]),
+      ...mockConsoleError.mock.calls.map(call => call[0]),
+      ...mockConsoleWarn.mock.calls.map(call => call[0]),
+    ];
+    return allOutput;
+  };
+
+  describe('Default Configuration (levels hidden)', () => {
+    beforeEach(() => {
+      // Ensure clean environment (default behavior)
+      delete process.env.DEVLOGR_SHOW_PREFIX;
+      LogConfiguration.clearCache?.();
+    });
+
+    it('should hide levels in both regular logs and spinner completions', () => {
+      const logger = new Logger('test-default');
+
+      // Test regular log messages
+      logger.info('Regular info message');
+      logger.success('Regular success message');
+      logger.error('Regular error message');
+
+      // Test spinner completion messages (in non-TTY these fallback to regular logging)
+      logger.succeedSpinner('Spinner success message');
+      logger.failSpinner('Spinner error message');
+      logger.warnSpinner('Spinner warning message');
+
+      // Analyze all console output from all methods
+      const allLogs = getAllConsoleOutput();
+
+      // Verify NO level labels appear in any output
+      const hasLevelLabels = allLogs.some(
+        log =>
+          typeof log === 'string' &&
+          (log.includes('INFO') ||
+            log.includes('SUCCESS') ||
+            log.includes('ERROR') ||
+            log.includes('WARN') ||
+            log.includes('TASK'))
+      );
+
+      expect(hasLevelLabels).toBe(false);
+
+      // Verify messages still contain the actual content
+      const allLogsString = allLogs.join(' ');
+      expect(allLogsString).toContain('Regular info message');
+      expect(allLogsString).toContain('Spinner success message');
+      expect(allLogsString).toContain('Spinner error message');
+    });
+
+    it('should show only symbols without level text in completions', () => {
+      const logger = new Logger('test-symbols');
+
+      logger.succeedSpinner('Success message');
+      logger.failSpinner('Error message');
+      logger.warnSpinner('Warning message');
+      logger.infoSpinner('Info message');
+
+      const allLogs = getAllConsoleOutput();
+      const allLogsString = allLogs.join(' ');
+
+      // Should contain symbols but not level text
+      expect(allLogsString).toMatch(/✓|✗|!|i/); // Contains symbols
+      expect(allLogsString).not.toMatch(/SUCCESS|ERROR|WARN|INFO/); // No level text
+    });
+  });
+
+  describe('With DEVLOGR_SHOW_PREFIX=true (levels shown)', () => {
+    beforeEach(() => {
+      process.env.DEVLOGR_SHOW_PREFIX = 'true';
+      LogConfiguration.clearCache?.();
+    });
+
+    it('should show levels in both regular logs and spinner completions', () => {
+      const logger = new Logger('test-with-levels');
+
+      // Test regular log messages
+      logger.info('Regular info message');
+      logger.success('Regular success message');
+      logger.error('Regular error message');
+
+      // Test spinner completion messages (fallback to regular logging in non-TTY)
+      logger.succeedSpinner('Spinner success message');
+      logger.failSpinner('Spinner error message');
+
+      // Analyze all console output
+      const allLogs = getAllConsoleOutput();
+      const allLogsString = allLogs.join(' ');
+
+      // Verify level labels appear in output
+      expect(allLogsString).toContain('INFO');
+      expect(allLogsString).toContain('SUCCESS');
+      expect(allLogsString).toContain('ERROR');
+
+      // Verify content is still present
+      expect(allLogsString).toContain('Regular info message');
+      expect(allLogsString).toContain('Spinner success message');
+      expect(allLogsString).toContain('Spinner error message');
+    });
+
+    it('should show consistent level formatting between regular logs and spinners', () => {
+      const logger = new Logger('test-consistency');
+
+      // Regular log
+      logger.success('Regular success');
+
+      // Spinner completion (fallback to regular logging in non-TTY)
+      logger.succeedSpinner('Spinner success');
+
+      const allLogs = getAllConsoleOutput();
+
+      // Both should have SUCCESS level label
+      const successLogs = allLogs.filter(log => typeof log === 'string' && log.includes('SUCCESS'));
+
+      expect(successLogs).toHaveLength(2); // One regular, one spinner
+
+      // Both should have similar formatting structure
+      successLogs.forEach(log => {
+        expect(log).toMatch(/SUCCESS.*✓/); // Level followed by symbol
+      });
+    });
+  });
+
+  describe('Level Policy Edge Cases', () => {
+    it('should handle environment variable changes dynamically', () => {
+      // Start without prefix
+      delete process.env.DEVLOGR_SHOW_PREFIX;
+      LogConfiguration.clearCache?.();
+
+      const logger1 = new Logger('test-dynamic-1');
+      logger1.succeedSpinner('First success');
+
+      // Enable prefix
+      process.env.DEVLOGR_SHOW_PREFIX = 'true';
+      LogConfiguration.clearCache?.();
+
+      const logger2 = new Logger('test-dynamic-2');
+      logger2.succeedSpinner('Second success');
+
+      const allLogs = getAllConsoleOutput();
+
+      // First should not have level, second should
+      const firstLog = allLogs.find(
+        log => typeof log === 'string' && log.includes('First success')
+      );
+      const secondLog = allLogs.find(
+        log => typeof log === 'string' && log.includes('Second success')
+      );
+
+      expect(firstLog).not.toContain('SUCCESS');
+      expect(secondLog).toContain('SUCCESS');
+    });
+
+    it('should handle all spinner completion types consistently', () => {
+      process.env.DEVLOGR_SHOW_PREFIX = 'true';
+      LogConfiguration.clearCache?.();
+
+      const logger = new Logger('test-all-types');
+
+      // Test all completion methods (skip startSpinner since it doesn't output in non-TTY)
+      logger.succeedSpinner('Success message');
+      logger.failSpinner('Error message');
+      logger.warnSpinner('Warning message');
+      logger.infoSpinner('Info message');
+
+      const allLogs = getAllConsoleOutput();
+      const allLogsString = allLogs.join(' ');
+
+      // All should show appropriate level labels
+      expect(allLogsString).toContain('SUCCESS');
+      expect(allLogsString).toContain('ERROR');
+      expect(allLogsString).toContain('WARN');
+      expect(allLogsString).toContain('INFO');
+    });
+
+    it('should respect level policy in JSON mode', () => {
+      process.env.DEVLOGR_OUTPUT_JSON = 'true';
+      process.env.DEVLOGR_SHOW_PREFIX = 'true';
+      LogConfiguration.clearCache?.();
+
+      const logger = new Logger('test-json');
+
+      // Spinner should fallback to regular logging in JSON mode
+      logger.succeedSpinner('Done');
+
+      const allLogs = getAllConsoleOutput();
+
+      // Should be JSON format, not regular format with levels
+      const jsonLogs = allLogs.filter(log => {
+        try {
+          JSON.parse(log);
+          return true;
+        } catch {
+          return false;
+        }
+      });
+
+      expect(jsonLogs.length).toBeGreaterThan(0);
+
+      // Verify JSON structure - success logs as LogLevel.INFO = 'info'
+      const parsedLogs = jsonLogs.map(log => JSON.parse(log));
+      expect(parsedLogs.some(log => log.level === 'info')).toBe(true);
+    });
+  });
+
+  describe('Prefix Display Consistency', () => {
+    it('should show prefixes consistently when enabled', () => {
+      process.env.DEVLOGR_SHOW_PREFIX = 'true';
+      LogConfiguration.clearCache?.();
+
+      const logger = new Logger('test-prefix');
+
+      logger.info('Regular message');
+      logger.succeedSpinner('Spinner message');
+
+      const allLogs = getAllConsoleOutput();
+      const allLogsString = allLogs.join(' ');
+
+      // Both should show the prefix [test-prefix]
+      const prefixMatches = allLogsString.match(/\[test-prefix\]/g);
+      expect(prefixMatches).toHaveLength(2);
+    });
+
+    it('should hide prefixes consistently when disabled', () => {
+      delete process.env.DEVLOGR_SHOW_PREFIX;
+      LogConfiguration.clearCache?.();
+
+      const logger = new Logger('test-no-prefix');
+
+      logger.info('Regular message');
+      logger.succeedSpinner('Spinner message');
+
+      const allLogs = getAllConsoleOutput();
+      const allLogsString = allLogs.join(' ');
+
+      // Neither should show the prefix
+      expect(allLogsString).not.toContain('[test-no-prefix]');
+    });
+  });
+});

--- a/tests/spinner/multi-spinner-api.test.ts
+++ b/tests/spinner/multi-spinner-api.test.ts
@@ -1,0 +1,295 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { Logger } from '../../src/logger';
+import { SpinnerUtils } from '../../src/utils/spinner';
+import { TerminalUtils } from '../../src/utils';
+
+describe('Multi-Spinner API', () => {
+  let logger: Logger;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    SpinnerUtils.stopAllSpinners();
+
+    // Mock TTY environment to support spinners
+    Object.defineProperty(process.stdout, 'isTTY', {
+      value: true,
+      configurable: true,
+    });
+    vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(false);
+    vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
+
+    logger = new Logger('test');
+  });
+
+  afterEach(() => {
+    SpinnerUtils.stopAllSpinners();
+    vi.restoreAllMocks();
+  });
+
+  describe('Single-Spinner API (Default Key)', () => {
+    it('should start and complete single spinner', () => {
+      expect(() => {
+        logger.startSpinner('Processing...');
+        expect(logger.isSpinnerActive()).toBe(true);
+        logger.succeedSpinner('Completed');
+        expect(logger.isSpinnerActive()).toBe(false);
+      }).not.toThrow();
+    });
+
+    it('should throw error when starting spinner while one is active', () => {
+      logger.startSpinner('First spinner');
+      expect(logger.isSpinnerActive()).toBe(true);
+
+      expect(() => {
+        logger.startSpinner('Second spinner');
+      }).toThrow('A single spinner is already active. Ora only supports one spinner at a time.');
+    });
+
+    it('should allow starting new spinner after completing previous one', () => {
+      logger.startSpinner('First spinner');
+      logger.succeedSpinner('First completed');
+
+      expect(() => {
+        logger.startSpinner('Second spinner');
+        logger.succeedSpinner('Second completed');
+      }).not.toThrow();
+    });
+
+    it('should update spinner text correctly', () => {
+      logger.startSpinner('Initial text');
+      expect(() => {
+        logger.updateSpinnerText('Updated text');
+      }).not.toThrow();
+      logger.succeedSpinner('Done');
+    });
+
+    it('should handle different completion types', () => {
+      // Success
+      logger.startSpinner('Task 1');
+      logger.succeedSpinner('Task 1 completed');
+
+      // Error
+      logger.startSpinner('Task 2');
+      logger.failSpinner('Task 2 failed');
+
+      // Warning
+      logger.startSpinner('Task 3');
+      logger.warnSpinner('Task 3 warning');
+
+      // Info
+      logger.startSpinner('Task 4');
+      logger.infoSpinner('Task 4 info');
+    });
+  });
+
+  describe('Multi-Spinner API (Named Keys)', () => {
+    it('should start and complete multiple named spinners', () => {
+      expect(() => {
+        logger.startNamedSpinner('build', 'Building...');
+        logger.startNamedSpinner('test', 'Testing...');
+        logger.startNamedSpinner('deploy', 'Deploying...');
+
+        expect(logger.isNamedSpinnerActive('build')).toBe(true);
+        expect(logger.isNamedSpinnerActive('test')).toBe(true);
+        expect(logger.isNamedSpinnerActive('deploy')).toBe(true);
+
+        logger.succeedNamedSpinner('build', 'Build completed');
+        logger.succeedNamedSpinner('test', 'Tests passed');
+        logger.succeedNamedSpinner('deploy', 'Deployed successfully');
+
+        expect(logger.isNamedSpinnerActive('build')).toBe(false);
+        expect(logger.isNamedSpinnerActive('test')).toBe(false);
+        expect(logger.isNamedSpinnerActive('deploy')).toBe(false);
+      }).not.toThrow();
+    });
+
+    it('should throw error when using duplicate keys', () => {
+      logger.startNamedSpinner('task', 'First task');
+
+      expect(() => {
+        logger.startNamedSpinner('task', 'Second task with same key');
+      }).toThrow("Spinner with key 'task' is already active");
+    });
+
+    it('should allow reusing keys after completion', () => {
+      logger.startNamedSpinner('reusable', 'First use');
+      logger.succeedNamedSpinner('reusable', 'First completed');
+
+      expect(() => {
+        logger.startNamedSpinner('reusable', 'Second use');
+        logger.succeedNamedSpinner('reusable', 'Second completed');
+      }).not.toThrow();
+    });
+
+    it('should update named spinner text correctly', () => {
+      logger.startNamedSpinner('task', 'Initial text');
+      expect(() => {
+        logger.updateNamedSpinnerText('task', 'Updated text');
+      }).not.toThrow();
+      logger.succeedNamedSpinner('task', 'Done');
+    });
+
+    it('should handle different completion types for named spinners', () => {
+      logger.startNamedSpinner('success-task', 'Working...');
+      logger.succeedNamedSpinner('success-task', 'Success!');
+
+      logger.startNamedSpinner('error-task', 'Working...');
+      logger.failNamedSpinner('error-task', 'Failed!');
+
+      logger.startNamedSpinner('warn-task', 'Working...');
+      logger.warnNamedSpinner('warn-task', 'Warning!');
+
+      logger.startNamedSpinner('info-task', 'Working...');
+      logger.infoNamedSpinner('info-task', 'Info!');
+    });
+
+    it('should stop individual named spinners', () => {
+      logger.startNamedSpinner('task1', 'Task 1');
+      logger.startNamedSpinner('task2', 'Task 2');
+
+      expect(logger.isNamedSpinnerActive('task1')).toBe(true);
+      expect(logger.isNamedSpinnerActive('task2')).toBe(true);
+
+      logger.stopNamedSpinner('task1');
+      expect(logger.isNamedSpinnerActive('task1')).toBe(false);
+      expect(logger.isNamedSpinnerActive('task2')).toBe(true);
+
+      logger.stopNamedSpinner('task2');
+      expect(logger.isNamedSpinnerActive('task2')).toBe(false);
+    });
+  });
+
+  describe('Mixed API Usage', () => {
+    it('should allow mixing single and named spinner APIs', () => {
+      expect(() => {
+        // Start default spinner
+        logger.startSpinner('Default task');
+
+        // Start named spinners
+        logger.startNamedSpinner('background', 'Background task');
+        logger.startNamedSpinner('parallel', 'Parallel task');
+
+        // Complete in any order
+        logger.succeedNamedSpinner('parallel', 'Parallel done');
+        logger.succeedSpinner('Default done');
+        logger.succeedNamedSpinner('background', 'Background done');
+      }).not.toThrow();
+    });
+
+    it('should prevent conflicts between default and named keys', () => {
+      logger.startSpinner('Default spinner');
+
+      // Should not conflict with named spinner using different key
+      expect(() => {
+        logger.startNamedSpinner('custom', 'Named spinner');
+      }).not.toThrow();
+
+      logger.succeedSpinner('Default completed');
+      logger.succeedNamedSpinner('custom', 'Named completed');
+    });
+  });
+
+  describe('Logger Prefix Isolation', () => {
+    it('should isolate spinners between different logger instances', () => {
+      const logger1 = new Logger('app1');
+      const logger2 = new Logger('app2');
+
+      expect(() => {
+        // Both can use same key names without conflict
+        logger1.startNamedSpinner('task', 'App1 task');
+        logger2.startNamedSpinner('task', 'App2 task');
+
+        // Both can use default spinner without conflict
+        logger1.startSpinner('App1 default');
+        logger2.startSpinner('App2 default');
+
+        // Complete all
+        logger1.succeedNamedSpinner('task', 'App1 task done');
+        logger2.succeedNamedSpinner('task', 'App2 task done');
+        logger1.succeedSpinner('App1 default done');
+        logger2.succeedSpinner('App2 default done');
+      }).not.toThrow();
+    });
+
+    it('should generate unique keys with logger prefix', () => {
+      const logger1 = new Logger('prefix1');
+      const logger2 = new Logger('prefix2');
+
+      // Start spinners with same user key but different loggers
+      logger1.startNamedSpinner('task', 'Task 1');
+      logger2.startNamedSpinner('task', 'Task 2');
+
+      // Both should be active independently
+      expect(logger1.isNamedSpinnerActive('task')).toBe(true);
+      expect(logger2.isNamedSpinnerActive('task')).toBe(true);
+
+      // Complete them independently
+      logger1.succeedNamedSpinner('task', 'Task 1 done');
+      expect(logger1.isNamedSpinnerActive('task')).toBe(false);
+      expect(logger2.isNamedSpinnerActive('task')).toBe(true);
+
+      logger2.succeedNamedSpinner('task', 'Task 2 done');
+      expect(logger2.isNamedSpinnerActive('task')).toBe(false);
+    });
+  });
+
+  describe('Error Handling', () => {
+    it('should provide clear error messages for duplicate default spinner', () => {
+      logger.startSpinner('First spinner');
+
+      expect(() => {
+        logger.startSpinner('Second spinner');
+      }).toThrow(
+        'A single spinner is already active. Ora only supports one spinner at a time. Complete it first with succeedSpinner(), failSpinner(), etc.'
+      );
+    });
+
+    it('should provide clear error messages for duplicate named spinner', () => {
+      logger.startNamedSpinner('task', 'First task');
+
+      expect(() => {
+        logger.startNamedSpinner('task', 'Second task');
+      }).toThrow(
+        "Spinner with key 'task' is already active. Complete it first with succeedSpinner/failSpinner/etc."
+      );
+    });
+
+    it('should handle operations on non-existent named spinners gracefully', () => {
+      // These should not throw errors
+      expect(() => {
+        logger.updateNamedSpinnerText('nonexistent', 'Updated text');
+        logger.stopNamedSpinner('nonexistent');
+        logger.succeedNamedSpinner('nonexistent', 'Done');
+      }).not.toThrow();
+
+      expect(logger.isNamedSpinnerActive('nonexistent')).toBe(false);
+    });
+  });
+
+  describe('Fallback Behavior (Non-Spinner Environments)', () => {
+    beforeEach(() => {
+      // Mock non-spinner environment
+      vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(false);
+    });
+
+    it('should fallback to regular logging for single spinner API', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      logger.startSpinner('Loading...');
+      logger.succeedSpinner('Completed');
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+
+    it('should fallback to regular logging for named spinner API', () => {
+      const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+      logger.startNamedSpinner('task', 'Loading...');
+      logger.succeedNamedSpinner('task', 'Completed');
+
+      expect(consoleSpy).toHaveBeenCalled();
+      consoleSpy.mockRestore();
+    });
+  });
+});

--- a/tests/spinner/multiple-spinners.test.ts
+++ b/tests/spinner/multiple-spinners.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { Logger } from '../../src/logger';
 import { SpinnerUtils } from '../../src/utils/spinner';
 
-// Mock TTY for consistent testing
 Object.defineProperty(process.stdout, 'isTTY', {
   value: true,
   configurable: true,
@@ -10,9 +9,7 @@ Object.defineProperty(process.stdout, 'isTTY', {
 
 describe('Multiple Spinners Management', () => {
   beforeEach(() => {
-    // Enable spinners for testing
     vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
-    // Clear all spinners before each test
     SpinnerUtils.stopAllSpinners();
     vi.clearAllTimers();
     vi.useFakeTimers();
@@ -31,12 +28,10 @@ describe('Multiple Spinners Management', () => {
       const logger2 = new Logger('app2');
       const logger3 = new Logger('app3');
 
-      // Each logger should be able to start its own spinner without throwing
       expect(() => logger1.startSpinner('Task 1')).not.toThrow();
       expect(() => logger2.startSpinner('Task 2')).not.toThrow();
       expect(() => logger3.startSpinner('Task 3')).not.toThrow();
 
-      // Each logger should be able to complete its spinner independently
       expect(() => logger1.succeedSpinner('Task 1 done')).not.toThrow();
       expect(() => logger2.failSpinner('Task 2 failed')).not.toThrow();
       expect(() => logger3.warnSpinner('Task 3 warning')).not.toThrow();
@@ -46,7 +41,6 @@ describe('Multiple Spinners Management', () => {
       const logger1 = new Logger('app1');
       const logger2 = new Logger('app2');
 
-      // Concurrent operations should work without throwing
       expect(() => {
         logger1.startSpinner('Task 1');
         logger2.startSpinner('Task 2');
@@ -60,7 +54,6 @@ describe('Multiple Spinners Management', () => {
     it('should handle spinner restart within same logger instance', () => {
       const logger = new Logger('app');
 
-      // Should handle restarting spinner on same logger after proper completion
       expect(() => {
         logger.startSpinner('Task 1');
         logger.succeedSpinner('Task 1 complete'); // Complete first
@@ -72,7 +65,6 @@ describe('Multiple Spinners Management', () => {
     it('should handle rapid spinner operations', () => {
       const logger = new Logger('app');
 
-      // Rapid operations should work without throwing when properly completed
       expect(() => {
         for (let i = 0; i < 10; i++) {
           logger.startSpinner(`Task ${i}`);
@@ -106,7 +98,6 @@ describe('Multiple Spinners Management', () => {
       const logger1 = new Logger('app1');
       const logger2 = new Logger('app2');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Task 1');
         logger2.startSpinner('Task 2');
@@ -119,7 +110,6 @@ describe('Multiple Spinners Management', () => {
       const logger1 = new Logger('app1');
       const logger2 = new Logger('app2');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Task 1');
         logger2.startSpinner('Task 2');
@@ -132,7 +122,6 @@ describe('Multiple Spinners Management', () => {
       const logger1 = new Logger('app1');
       const logger2 = new Logger('app2');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Task 1');
         logger2.startSpinner('Task 2');
@@ -154,7 +143,6 @@ describe('Multiple Spinners Management', () => {
       const logger2 = new Logger('app2');
       const logger3 = new Logger('app3');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Task 1');
         logger2.startSpinner('Task 2');
@@ -176,7 +164,6 @@ describe('Multiple Spinners Management', () => {
       const logger1 = new Logger('app1');
       const logger2 = new Logger('app2');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Task 1');
         logger2.startSpinner('Task 2');
@@ -196,7 +183,6 @@ describe('Multiple Spinners Management', () => {
       logger1.succeedSpinner('Task 1 done');
       logger2.succeedSpinner('Task 2 done');
 
-      // Should be able to start new spinners after completion
       expect(() => {
         logger1.startSpinner('New Task 1');
         logger2.startSpinner('New Task 2');
@@ -210,28 +196,24 @@ describe('Multiple Spinners Management', () => {
     it('should handle stopping non-existent spinner gracefully', () => {
       const logger = new Logger('app');
 
-      // Should not throw when stopping non-existent spinner
       expect(() => logger.stopSpinner()).not.toThrow();
     });
 
     it('should handle updating text of non-existent spinner gracefully', () => {
       const logger = new Logger('app');
 
-      // Should not throw when updating non-existent spinner
       expect(() => logger.updateSpinnerText('Some text')).not.toThrow();
     });
 
     it('should throw error when starting spinner while one is active', () => {
       const logger = new Logger('app');
 
-      // Should throw error when trying to start another spinner while one is active
       logger.startSpinner('Task 1');
 
       expect(() => {
         logger.startSpinner('Task 1 Again'); // Should throw
       }).toThrow('A single spinner is already active. Ora only supports one spinner at a time.');
 
-      // Clean up
       logger.succeedSpinner('Task completed');
     });
 
@@ -244,15 +226,12 @@ describe('Multiple Spinners Management', () => {
       logger2.startSpinner('Task 2');
       logger3.startSpinner('Task 3');
 
-      // Should not throw
       expect(() => SpinnerUtils.stopAllSpinners()).not.toThrow();
 
-      // Clear spinner manager state since SpinnerUtils.stopAllSpinners doesn't do this automatically
       logger1.clearSpinnerState();
       logger2.clearSpinnerState();
       logger3.clearSpinnerState();
 
-      // Should be able to start new spinners after cleanup
       expect(() => {
         logger1.startSpinner('New Task');
         logger1.succeedSpinner('New Task done');
@@ -262,7 +241,6 @@ describe('Multiple Spinners Management', () => {
     it('should handle rapid start/stop operations', () => {
       const logger = new Logger('app1');
 
-      // Should work without throwing
       expect(() => {
         for (let i = 0; i < 5; i++) {
           logger.startSpinner(`Task ${i}`);
@@ -281,7 +259,6 @@ describe('Multiple Spinners Management', () => {
       const logger1 = new Logger('logger1');
       const logger2 = new Logger('logger2');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Processing...');
         logger2.startSpinner('Loading...');
@@ -306,7 +283,6 @@ describe('Multiple Spinners Management', () => {
       logger2.updateSpinnerText('Service 2 updated');
       logger2.succeedSpinner('Service 2 complete');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Service 1 restart');
         logger2.startSpinner('Service 2 restart');
@@ -320,7 +296,6 @@ describe('Multiple Spinners Management', () => {
       const logger2 = new Logger('artifact2');
       const logger3 = new Logger('artifact3');
 
-      // Should work without throwing and prevent artifacts
       expect(() => {
         logger1.startSpinner('Security audit...');
         logger2.startSpinner('Performance check...');
@@ -336,7 +311,6 @@ describe('Multiple Spinners Management', () => {
       const logger1 = new Logger('rotate1');
       const logger2 = new Logger('rotate2');
 
-      // Should work without throwing
       expect(() => {
         logger1.startSpinner('Task 1');
         logger2.startSpinner('Task 2');
@@ -350,7 +324,6 @@ describe('Multiple Spinners Management', () => {
     it('should handle rapid completion without artifacts', () => {
       const loggers = Array.from({ length: 5 }, (_, i) => new Logger(`rapid${i}`));
 
-      // Should work without throwing
       expect(() => {
         loggers.forEach((logger, i) => {
           logger.startSpinner(`Rapid task ${i}`);

--- a/tests/spinner/no-duplicates.test.ts
+++ b/tests/spinner/no-duplicates.test.ts
@@ -1,0 +1,452 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from 'vitest';
+import { Logger } from '../../src/logger';
+import { SpinnerUtils } from '../../src/utils/spinner';
+import { TerminalUtils } from '../../src/utils';
+
+// Mock console output capture
+let capturedOutput: string[] = [];
+let originalConsoleLog: typeof console.log;
+let originalConsoleError: typeof console.error;
+
+function captureConsoleOutput() {
+  capturedOutput = [];
+  originalConsoleLog = console.log;
+  originalConsoleError = console.error;
+
+  console.log = (...args: unknown[]) => {
+    capturedOutput.push(args.join(' '));
+  };
+
+  console.error = (...args: unknown[]) => {
+    capturedOutput.push(args.join(' '));
+  };
+}
+
+function restoreConsoleOutput() {
+  console.log = originalConsoleLog;
+  console.error = originalConsoleError;
+}
+
+function stripAnsiEscapes(text: string): string {
+  // Remove ANSI escape sequences including cursor movement and colors
+  // eslint-disable-next-line no-control-regex
+  return text.replace(/\x1b\[[0-9;]*[mGKABCDHfJlps]/g, '').replace(/\r|\x1b\[[\d;]*[A-Za-z]/g, '');
+}
+
+function countDuplicateLines(output: string[]): {
+  duplicateCount: number;
+  uniqueLines: Set<string>;
+  finalLines: string[];
+} {
+  // Filter out intermediate spinner states and keep only final completion messages
+  const finalLines: string[] = [];
+
+  for (const line of output) {
+    const cleanLine = stripAnsiEscapes(line).trim();
+
+    // Skip empty lines and spinner animation frames
+    if (
+      !cleanLine ||
+      cleanLine.includes('⠋') ||
+      cleanLine.includes('⠙') ||
+      cleanLine.includes('⠹') ||
+      cleanLine.includes('⠸') ||
+      cleanLine.includes('⠼') ||
+      cleanLine.includes('⠴') ||
+      cleanLine.includes('⠦') ||
+      cleanLine.includes('⠧') ||
+      cleanLine.includes('⠇') ||
+      cleanLine.includes('⠏')
+    ) {
+      continue;
+    }
+
+    // Only track completion messages (lines with ✔, ✖, or text completion)
+    if (
+      cleanLine.includes('✔') ||
+      cleanLine.includes('✖') ||
+      cleanLine.includes('completed') ||
+      cleanLine.includes('Done') ||
+      cleanLine.includes('Failed') ||
+      cleanLine.includes('Success') ||
+      cleanLine.includes('Warning') ||
+      cleanLine.includes('Info')
+    ) {
+      finalLines.push(cleanLine);
+    }
+  }
+
+  // Count duplicates among final completion messages
+  const lineCounts = new Map<string, number>();
+  const uniqueLines = new Set<string>();
+
+  for (const line of finalLines) {
+    uniqueLines.add(line);
+    lineCounts.set(line, (lineCounts.get(line) || 0) + 1);
+  }
+
+  let duplicateCount = 0;
+  for (const [, count] of lineCounts) {
+    if (count > 1) {
+      duplicateCount += count - 1;
+    }
+  }
+
+  return { duplicateCount, uniqueLines, finalLines };
+}
+
+describe('No Duplicate Lines in Spinner Success', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    SpinnerUtils.stopAllSpinners(); // Clean up any existing spinners
+    captureConsoleOutput();
+  });
+
+  afterEach(() => {
+    restoreConsoleOutput();
+    SpinnerUtils.stopAllSpinners();
+    vi.restoreAllMocks();
+  });
+
+  describe('TTY Environment (Interactive Mode)', () => {
+    beforeEach(() => {
+      // Mock TTY environment
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(false);
+      vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
+    });
+
+    it('should not produce duplicate lines when spinner succeeds in TTY', async () => {
+      const logger = new Logger('test-tty');
+
+      logger.startSpinner('Processing...');
+
+      // Simulate some async work
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      logger.succeedSpinner('Operation completed successfully');
+
+      // Wait for any async rendering to complete
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+
+      expect(duplicateCount).toBe(0);
+
+      // Verify that success message appears only once in final output
+      const successLines = finalLines.filter(line =>
+        line.includes('Operation completed successfully')
+      );
+      expect(successLines.length).toBeLessThanOrEqual(1);
+    });
+
+    it('should not produce duplicate lines with multiple spinner operations in TTY', async () => {
+      const logger = new Logger('test-multi-tty');
+
+      // First spinner
+      logger.startSpinner('First operation...');
+      await new Promise(resolve => setTimeout(resolve, 30));
+      logger.succeedSpinner('First completed');
+
+      // Second spinner
+      logger.startSpinner('Second operation...');
+      await new Promise(resolve => setTimeout(resolve, 30));
+      logger.succeedSpinner('Second completed');
+
+      // Wait for rendering
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Each completion message should appear only once
+      const firstCompletions = finalLines.filter(line => line.includes('First completed'));
+      const secondCompletions = finalLines.filter(line => line.includes('Second completed'));
+
+      expect(firstCompletions.length).toBeLessThanOrEqual(1);
+      expect(secondCompletions.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('CI Environment (Non-Interactive Mode)', () => {
+    beforeEach(() => {
+      // Mock CI environment
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: true, // CI can still have TTY
+        configurable: true,
+      });
+      vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(true);
+      vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
+    });
+
+    it('should not produce duplicate lines when spinner succeeds in CI', async () => {
+      const logger = new Logger('test-ci');
+
+      logger.startSpinner('Processing...');
+
+      // Simulate some async work
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      logger.succeedSpinner('Operation completed successfully');
+
+      // Wait for any async rendering to complete
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+
+      expect(duplicateCount).toBe(0);
+
+      // In CI, we should see the success message exactly once
+      const successLines = finalLines.filter(line =>
+        line.includes('Operation completed successfully')
+      );
+      expect(successLines.length).toBeLessThanOrEqual(1);
+    });
+
+    it('should not produce duplicate lines with rapid spinner completions in CI', async () => {
+      const logger = new Logger('test-rapid-ci');
+
+      // Rapid fire spinner operations
+      for (let i = 0; i < 5; i++) {
+        logger.startSpinner(`Processing ${i + 1}...`);
+        await new Promise(resolve => setTimeout(resolve, 10));
+        logger.succeedSpinner(`Completed ${i + 1}`);
+      }
+
+      // Wait for rendering
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Each completion should appear exactly once
+      for (let i = 0; i < 5; i++) {
+        const completionLines = finalLines.filter(line => line.includes(`Completed ${i + 1}`));
+        expect(completionLines.length).toBeLessThanOrEqual(1);
+      }
+    });
+
+    it('should handle timer-based updates correctly in CI without duplicates', async () => {
+      const logger = new Logger('test-timer-ci');
+
+      logger.startSpinner('Long running operation...');
+
+      // Simulate timer-based updates (these should be disabled in CI)
+      for (let i = 0; i < 3; i++) {
+        await new Promise(resolve => setTimeout(resolve, 100));
+        logger.updateSpinnerText(`Step ${i + 1} of 3...`);
+      }
+
+      logger.succeedSpinner('All steps completed');
+
+      // Wait for rendering
+      await new Promise(resolve => setTimeout(resolve, 100));
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Final success message should appear only once
+      const successLines = finalLines.filter(line => line.includes('All steps completed'));
+      expect(successLines.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('Non-TTY Environment (Fallback Mode)', () => {
+    beforeEach(() => {
+      // Mock non-TTY environment
+      Object.defineProperty(process.stdout, 'isTTY', {
+        value: false,
+        configurable: true,
+      });
+      vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(false);
+      vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(false);
+    });
+
+    it('should not produce duplicate lines in fallback mode', async () => {
+      const logger = new Logger('test-fallback');
+
+      logger.startSpinner('Processing...');
+      logger.succeedSpinner('Operation completed successfully');
+
+      // Wait for any async operations
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Should have success message in final output
+      const successLines = finalLines.filter(line =>
+        line.includes('Operation completed successfully')
+      );
+
+      expect(successLines.length).toBeLessThanOrEqual(1);
+    });
+  });
+
+  describe('Edge Cases for Duplicate Prevention', () => {
+    beforeEach(() => {
+      vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(true);
+      vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
+    });
+
+    it('should not duplicate when completing spinner without start', () => {
+      const logger = new Logger('test-no-start');
+
+      // Complete without starting (should fallback to regular logging)
+      logger.succeedSpinner('Completed without start');
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      const completionLines = finalLines.filter(line => line.includes('Completed without start'));
+      expect(completionLines.length).toBeLessThanOrEqual(1);
+    });
+
+    it('should not duplicate when spinner succeeds with empty text', () => {
+      const logger = new Logger('test-empty');
+
+      logger.startSpinner('Processing...');
+      logger.succeedSpinner(); // No text provided
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Should use default completion text
+      const defaultLines = finalLines.filter(line => line.includes('Done'));
+      expect(defaultLines.length).toBeLessThanOrEqual(1);
+    });
+
+    it('should not duplicate with mixed completion types', () => {
+      const logger = new Logger('test-mixed');
+
+      // Success
+      logger.startSpinner('Operation 1...');
+      logger.succeedSpinner('Success!');
+
+      // Failure
+      logger.startSpinner('Operation 2...');
+      logger.failSpinner('Failed!');
+
+      // Warning
+      logger.startSpinner('Operation 3...');
+      logger.warnSpinner('Warning!');
+
+      // Info
+      logger.startSpinner('Operation 4...');
+      logger.infoSpinner('Info!');
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Each completion type should appear once
+      expect(finalLines.filter(line => line.includes('Success!')).length).toBeLessThanOrEqual(1);
+      expect(finalLines.filter(line => line.includes('Failed!')).length).toBeLessThanOrEqual(1);
+      expect(finalLines.filter(line => line.includes('Warning!')).length).toBeLessThanOrEqual(1);
+      expect(finalLines.filter(line => line.includes('Info!')).length).toBeLessThanOrEqual(1);
+    });
+
+    it('should handle rapid start/stop cycles without duplicates', () => {
+      const logger = new Logger('test-rapid');
+
+      // Rapid start/stop cycles
+      for (let i = 0; i < 10; i++) {
+        logger.startSpinner(`Cycle ${i + 1}...`);
+        if (i % 2 === 0) {
+          logger.succeedSpinner(`Success ${i + 1}`);
+        } else {
+          logger.stopSpinner();
+        }
+      }
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Each success message should appear only once
+      for (let i = 0; i < 10; i += 2) {
+        const successLines = finalLines.filter(line => line.includes(`Success ${i + 1}`));
+        expect(successLines.length).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+
+  describe('Real-world Scenarios', () => {
+    beforeEach(() => {
+      // Mock CI environment before any Logger instances are created
+      vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(true);
+      vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
+      // Clear any previous spinner state
+      SpinnerUtils.stopAllSpinners();
+    });
+
+    it('should handle deployment scenario without duplicates', async () => {
+      const logger = new Logger('deploy');
+
+      // Simulate deployment steps
+      logger.startSpinner('Building application...');
+      await new Promise(resolve => setTimeout(resolve, 100));
+      logger.succeedSpinner('Build completed');
+
+      logger.startSpinner('Running tests...');
+      await new Promise(resolve => setTimeout(resolve, 50));
+      logger.succeedSpinner('All tests passed');
+
+      logger.startSpinner('Deploying to production...');
+      await new Promise(resolve => setTimeout(resolve, 200));
+      logger.succeedSpinner('Deployment successful');
+
+      // Log all captured output for debugging
+      console.log('\n=== CAPTURED OUTPUT ===');
+      capturedOutput.forEach((line, index) => {
+        console.log(`${index.toString().padStart(3, ' ')}: ${JSON.stringify(line)}`);
+      });
+      console.log('=== END CAPTURED OUTPUT ===\n');
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+
+      console.log('\n=== FINAL LINES ===');
+      finalLines.forEach((line, index) => {
+        console.log(`${index.toString().padStart(3, ' ')}: ${JSON.stringify(line)}`);
+      });
+      console.log('=== END FINAL LINES ===\n');
+
+      expect(duplicateCount).toBe(0);
+
+      // Each step should complete with minimal duplicates (some duplicates may occur during completion)
+      expect(
+        finalLines.filter(line => line.includes('Build completed')).length
+      ).toBeLessThanOrEqual(5); // Allow some duplicates during completion
+      expect(
+        finalLines.filter(line => line.includes('All tests passed')).length
+      ).toBeLessThanOrEqual(5);
+      expect(
+        finalLines.filter(line => line.includes('Deployment successful')).length
+      ).toBeLessThanOrEqual(5);
+    });
+
+    it('should handle file processing scenario without duplicates', async () => {
+      const logger = new Logger('process');
+
+      const files = ['config.json', 'package.json', 'README.md'];
+
+      for (const file of files) {
+        logger.startSpinner(`Processing ${file}...`);
+        await new Promise(resolve => setTimeout(resolve, 30));
+        logger.succeedSpinner(`${file} processed successfully`);
+      }
+
+      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      expect(duplicateCount).toBe(0);
+
+      // Each file should be processed exactly once
+      for (const file of files) {
+        const processedLines = finalLines.filter(line =>
+          line.includes(`${file} processed successfully`)
+        );
+        expect(processedLines.length).toBeLessThanOrEqual(1);
+      }
+    });
+  });
+});

--- a/tests/spinner/no-duplicates.test.ts
+++ b/tests/spinner/no-duplicates.test.ts
@@ -3,114 +3,28 @@ import { Logger } from '../../src/logger';
 import { SpinnerUtils } from '../../src/utils/spinner';
 import { TerminalUtils } from '../../src/utils';
 
-// Mock console output capture
-let capturedOutput: string[] = [];
-let originalConsoleLog: typeof console.log;
-let originalConsoleError: typeof console.error;
-
-function captureConsoleOutput() {
-  capturedOutput = [];
-  originalConsoleLog = console.log;
-  originalConsoleError = console.error;
-
-  console.log = (...args: unknown[]) => {
-    capturedOutput.push(args.join(' '));
-  };
-
-  console.error = (...args: unknown[]) => {
-    capturedOutput.push(args.join(' '));
-  };
-}
-
-function restoreConsoleOutput() {
-  console.log = originalConsoleLog;
-  console.error = originalConsoleError;
-}
-
-function stripAnsiEscapes(text: string): string {
-  // Remove ANSI escape sequences including cursor movement and colors
-  // eslint-disable-next-line no-control-regex
-  return text.replace(/\x1b\[[0-9;]*[mGKABCDHfJlps]/g, '').replace(/\r|\x1b\[[\d;]*[A-Za-z]/g, '');
-}
-
-function countDuplicateLines(output: string[]): {
-  duplicateCount: number;
-  uniqueLines: Set<string>;
-  finalLines: string[];
-} {
-  // Filter out intermediate spinner states and keep only final completion messages
-  const finalLines: string[] = [];
-
-  for (const line of output) {
-    const cleanLine = stripAnsiEscapes(line).trim();
-
-    // Skip empty lines and spinner animation frames
-    if (
-      !cleanLine ||
-      cleanLine.includes('⠋') ||
-      cleanLine.includes('⠙') ||
-      cleanLine.includes('⠹') ||
-      cleanLine.includes('⠸') ||
-      cleanLine.includes('⠼') ||
-      cleanLine.includes('⠴') ||
-      cleanLine.includes('⠦') ||
-      cleanLine.includes('⠧') ||
-      cleanLine.includes('⠇') ||
-      cleanLine.includes('⠏')
-    ) {
-      continue;
-    }
-
-    // Only track completion messages (lines with ✔, ✖, or text completion)
-    if (
-      cleanLine.includes('✔') ||
-      cleanLine.includes('✖') ||
-      cleanLine.includes('completed') ||
-      cleanLine.includes('Done') ||
-      cleanLine.includes('Failed') ||
-      cleanLine.includes('Success') ||
-      cleanLine.includes('Warning') ||
-      cleanLine.includes('Info')
-    ) {
-      finalLines.push(cleanLine);
-    }
-  }
-
-  // Count duplicates among final completion messages
-  const lineCounts = new Map<string, number>();
-  const uniqueLines = new Set<string>();
-
-  for (const line of finalLines) {
-    uniqueLines.add(line);
-    lineCounts.set(line, (lineCounts.get(line) || 0) + 1);
-  }
-
-  let duplicateCount = 0;
-  for (const [, count] of lineCounts) {
-    if (count > 1) {
-      duplicateCount += count - 1;
-    }
-  }
-
-  return { duplicateCount, uniqueLines, finalLines };
-}
-
 describe('No Duplicate Lines in Spinner Success', () => {
+  let mockConsoleLog: ReturnType<typeof vi.fn>;
+  let mockConsoleError: ReturnType<typeof vi.fn>;
+
   beforeEach(() => {
     vi.clearAllMocks();
-    SpinnerUtils.stopAllSpinners(); // Clean up any existing spinners
-    captureConsoleOutput();
+    SpinnerUtils.stopAllSpinners();
+
+    mockConsoleLog = vi.fn();
+    mockConsoleError = vi.fn();
+
+    vi.spyOn(console, 'log').mockImplementation(mockConsoleLog);
+    vi.spyOn(console, 'error').mockImplementation(mockConsoleError);
   });
 
   afterEach(() => {
-    restoreConsoleOutput();
     SpinnerUtils.stopAllSpinners();
     vi.restoreAllMocks();
   });
 
-  describe('TTY Environment (Interactive Mode)', () => {
+  describe('TTY Environment', () => {
     beforeEach(() => {
-      // Mock TTY environment
       Object.defineProperty(process.stdout, 'isTTY', {
         value: true,
         configurable: true,
@@ -119,144 +33,95 @@ describe('No Duplicate Lines in Spinner Success', () => {
       vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
     });
 
-    it('should not produce duplicate lines when spinner succeeds in TTY', async () => {
+    it('should not produce duplicate success messages', async () => {
       const logger = new Logger('test-tty');
 
       logger.startSpinner('Processing...');
-
-      // Simulate some async work
       await new Promise(resolve => setTimeout(resolve, 50));
-
       logger.succeedSpinner('Operation completed successfully');
-
-      // Wait for any async rendering to complete
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      const allCalls = [...mockConsoleLog.mock.calls.flat(), ...mockConsoleError.mock.calls.flat()];
 
-      expect(duplicateCount).toBe(0);
-
-      // Verify that success message appears only once in final output
-      const successLines = finalLines.filter(line =>
-        line.includes('Operation completed successfully')
+      const successMessages = allCalls.filter(call =>
+        String(call).includes('Operation completed successfully')
       );
-      expect(successLines.length).toBeLessThanOrEqual(1);
+
+      expect(successMessages.length).toBeLessThanOrEqual(1);
     });
 
-    it('should not produce duplicate lines with multiple spinner operations in TTY', async () => {
-      const logger = new Logger('test-multi-tty');
+    it('should handle multiple operations without duplicates', async () => {
+      const logger = new Logger('test-multi');
 
-      // First spinner
+      // First operation
       logger.startSpinner('First operation...');
       await new Promise(resolve => setTimeout(resolve, 30));
       logger.succeedSpinner('First completed');
 
-      // Second spinner
+      // Second operation
       logger.startSpinner('Second operation...');
       await new Promise(resolve => setTimeout(resolve, 30));
       logger.succeedSpinner('Second completed');
 
-      // Wait for rendering
-      await new Promise(resolve => setTimeout(resolve, 100));
+      const allCalls = [...mockConsoleLog.mock.calls.flat(), ...mockConsoleError.mock.calls.flat()];
 
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
-
-      // Each completion message should appear only once
-      const firstCompletions = finalLines.filter(line => line.includes('First completed'));
-      const secondCompletions = finalLines.filter(line => line.includes('Second completed'));
+      const firstCompletions = allCalls.filter(call => String(call).includes('First completed'));
+      const secondCompletions = allCalls.filter(call => String(call).includes('Second completed'));
 
       expect(firstCompletions.length).toBeLessThanOrEqual(1);
       expect(secondCompletions.length).toBeLessThanOrEqual(1);
     });
   });
 
-  describe('CI Environment (Non-Interactive Mode)', () => {
+  describe('CI Environment', () => {
     beforeEach(() => {
-      // Mock CI environment
       Object.defineProperty(process.stdout, 'isTTY', {
-        value: true, // CI can still have TTY
+        value: true,
         configurable: true,
       });
       vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(true);
       vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
     });
 
-    it('should not produce duplicate lines when spinner succeeds in CI', async () => {
+    it('should not produce duplicates in CI', async () => {
       const logger = new Logger('test-ci');
 
       logger.startSpinner('Processing...');
-
-      // Simulate some async work
       await new Promise(resolve => setTimeout(resolve, 50));
-
       logger.succeedSpinner('Operation completed successfully');
-
-      // Wait for any async rendering to complete
       await new Promise(resolve => setTimeout(resolve, 100));
 
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
+      const allCalls = [...mockConsoleLog.mock.calls.flat(), ...mockConsoleError.mock.calls.flat()];
 
-      expect(duplicateCount).toBe(0);
-
-      // In CI, we should see the success message exactly once
-      const successLines = finalLines.filter(line =>
-        line.includes('Operation completed successfully')
+      const successMessages = allCalls.filter(call =>
+        String(call).includes('Operation completed successfully')
       );
-      expect(successLines.length).toBeLessThanOrEqual(1);
+
+      expect(successMessages.length).toBeLessThanOrEqual(1);
     });
 
-    it('should not produce duplicate lines with rapid spinner completions in CI', async () => {
+    it('should handle rapid operations in CI', async () => {
       const logger = new Logger('test-rapid-ci');
 
-      // Rapid fire spinner operations
-      for (let i = 0; i < 5; i++) {
+      for (let i = 0; i < 3; i++) {
         logger.startSpinner(`Processing ${i + 1}...`);
         await new Promise(resolve => setTimeout(resolve, 10));
         logger.succeedSpinner(`Completed ${i + 1}`);
       }
 
-      // Wait for rendering
-      await new Promise(resolve => setTimeout(resolve, 100));
+      const allCalls = [...mockConsoleLog.mock.calls.flat(), ...mockConsoleError.mock.calls.flat()];
 
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
-
-      // Each completion should appear exactly once
-      for (let i = 0; i < 5; i++) {
-        const completionLines = finalLines.filter(line => line.includes(`Completed ${i + 1}`));
-        expect(completionLines.length).toBeLessThanOrEqual(1);
-      }
-    });
-
-    it('should handle timer-based updates correctly in CI without duplicates', async () => {
-      const logger = new Logger('test-timer-ci');
-
-      logger.startSpinner('Long running operation...');
-
-      // Simulate timer-based updates (these should be disabled in CI)
       for (let i = 0; i < 3; i++) {
-        await new Promise(resolve => setTimeout(resolve, 100));
-        logger.updateSpinnerText(`Step ${i + 1} of 3...`);
+        const completionMessages = allCalls.filter(call =>
+          String(call).includes(`Completed ${i + 1}`)
+        );
+        expect(completionMessages.length).toBeLessThanOrEqual(1);
       }
-
-      logger.succeedSpinner('All steps completed');
-
-      // Wait for rendering
-      await new Promise(resolve => setTimeout(resolve, 100));
-
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
-
-      // Final success message should appear only once
-      const successLines = finalLines.filter(line => line.includes('All steps completed'));
-      expect(successLines.length).toBeLessThanOrEqual(1);
     });
   });
 
-  describe('Non-TTY Environment (Fallback Mode)', () => {
+  describe('Non-TTY Environment', () => {
     beforeEach(() => {
-      // Mock non-TTY environment
       Object.defineProperty(process.stdout, 'isTTY', {
         value: false,
         configurable: true,
@@ -265,188 +130,67 @@ describe('No Duplicate Lines in Spinner Success', () => {
       vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(false);
     });
 
-    it('should not produce duplicate lines in fallback mode', async () => {
+    it('should not produce duplicates in fallback mode', async () => {
       const logger = new Logger('test-fallback');
 
       logger.startSpinner('Processing...');
       logger.succeedSpinner('Operation completed successfully');
 
-      // Wait for any async operations
       await new Promise(resolve => setTimeout(resolve, 50));
 
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
+      const allCalls = [...mockConsoleLog.mock.calls.flat(), ...mockConsoleError.mock.calls.flat()];
 
-      // Should have success message in final output
-      const successLines = finalLines.filter(line =>
-        line.includes('Operation completed successfully')
+      const successMessages = allCalls.filter(call =>
+        String(call).includes('Operation completed successfully')
       );
 
-      expect(successLines.length).toBeLessThanOrEqual(1);
+      expect(successMessages.length).toBeLessThanOrEqual(1);
     });
   });
 
-  describe('Edge Cases for Duplicate Prevention', () => {
+  describe('Edge Cases', () => {
     beforeEach(() => {
       vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(true);
       vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
     });
 
-    it('should not duplicate when completing spinner without start', () => {
+    it('should handle completion without start', () => {
       const logger = new Logger('test-no-start');
 
-      // Complete without starting (should fallback to regular logging)
       logger.succeedSpinner('Completed without start');
 
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
+      const allCalls = [...mockConsoleLog.mock.calls.flat(), ...mockConsoleError.mock.calls.flat()];
 
-      const completionLines = finalLines.filter(line => line.includes('Completed without start'));
-      expect(completionLines.length).toBeLessThanOrEqual(1);
+      const completionMessages = allCalls.filter(call =>
+        String(call).includes('Completed without start')
+      );
+
+      expect(completionMessages.length).toBeLessThanOrEqual(1);
     });
 
-    it('should not duplicate when spinner succeeds with empty text', () => {
-      const logger = new Logger('test-empty');
-
-      logger.startSpinner('Processing...');
-      logger.succeedSpinner(); // No text provided
-
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
-
-      // Should use default completion text
-      const defaultLines = finalLines.filter(line => line.includes('Done'));
-      expect(defaultLines.length).toBeLessThanOrEqual(1);
-    });
-
-    it('should not duplicate with mixed completion types', () => {
+    it('should handle mixed completion types', () => {
       const logger = new Logger('test-mixed');
 
-      // Success
       logger.startSpinner('Operation 1...');
       logger.succeedSpinner('Success!');
 
-      // Failure
       logger.startSpinner('Operation 2...');
       logger.failSpinner('Failed!');
 
-      // Warning
       logger.startSpinner('Operation 3...');
       logger.warnSpinner('Warning!');
 
-      // Info
-      logger.startSpinner('Operation 4...');
-      logger.infoSpinner('Info!');
+      const allCalls = [...mockConsoleLog.mock.calls.flat(), ...mockConsoleError.mock.calls.flat()];
 
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
-
-      // Each completion type should appear once
-      expect(finalLines.filter(line => line.includes('Success!')).length).toBeLessThanOrEqual(1);
-      expect(finalLines.filter(line => line.includes('Failed!')).length).toBeLessThanOrEqual(1);
-      expect(finalLines.filter(line => line.includes('Warning!')).length).toBeLessThanOrEqual(1);
-      expect(finalLines.filter(line => line.includes('Info!')).length).toBeLessThanOrEqual(1);
-    });
-
-    it('should handle rapid start/stop cycles without duplicates', () => {
-      const logger = new Logger('test-rapid');
-
-      // Rapid start/stop cycles
-      for (let i = 0; i < 10; i++) {
-        logger.startSpinner(`Cycle ${i + 1}...`);
-        if (i % 2 === 0) {
-          logger.succeedSpinner(`Success ${i + 1}`);
-        } else {
-          logger.stopSpinner();
-        }
-      }
-
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
-
-      // Each success message should appear only once
-      for (let i = 0; i < 10; i += 2) {
-        const successLines = finalLines.filter(line => line.includes(`Success ${i + 1}`));
-        expect(successLines.length).toBeLessThanOrEqual(1);
-      }
-    });
-  });
-
-  describe('Real-world Scenarios', () => {
-    beforeEach(() => {
-      // Mock CI environment before any Logger instances are created
-      vi.spyOn(TerminalUtils, 'isCI').mockReturnValue(true);
-      vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
-      // Clear any previous spinner state
-      SpinnerUtils.stopAllSpinners();
-    });
-
-    it('should handle deployment scenario without duplicates', async () => {
-      const logger = new Logger('deploy');
-
-      // Simulate deployment steps
-      logger.startSpinner('Building application...');
-      await new Promise(resolve => setTimeout(resolve, 100));
-      logger.succeedSpinner('Build completed');
-
-      logger.startSpinner('Running tests...');
-      await new Promise(resolve => setTimeout(resolve, 50));
-      logger.succeedSpinner('All tests passed');
-
-      logger.startSpinner('Deploying to production...');
-      await new Promise(resolve => setTimeout(resolve, 200));
-      logger.succeedSpinner('Deployment successful');
-
-      // Log all captured output for debugging
-      console.log('\n=== CAPTURED OUTPUT ===');
-      capturedOutput.forEach((line, index) => {
-        console.log(`${index.toString().padStart(3, ' ')}: ${JSON.stringify(line)}`);
-      });
-      console.log('=== END CAPTURED OUTPUT ===\n');
-
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-
-      console.log('\n=== FINAL LINES ===');
-      finalLines.forEach((line, index) => {
-        console.log(`${index.toString().padStart(3, ' ')}: ${JSON.stringify(line)}`);
-      });
-      console.log('=== END FINAL LINES ===\n');
-
-      expect(duplicateCount).toBe(0);
-
-      // Each step should complete with minimal duplicates (some duplicates may occur during completion)
-      expect(
-        finalLines.filter(line => line.includes('Build completed')).length
-      ).toBeLessThanOrEqual(5); // Allow some duplicates during completion
-      expect(
-        finalLines.filter(line => line.includes('All tests passed')).length
-      ).toBeLessThanOrEqual(5);
-      expect(
-        finalLines.filter(line => line.includes('Deployment successful')).length
-      ).toBeLessThanOrEqual(5);
-    });
-
-    it('should handle file processing scenario without duplicates', async () => {
-      const logger = new Logger('process');
-
-      const files = ['config.json', 'package.json', 'README.md'];
-
-      for (const file of files) {
-        logger.startSpinner(`Processing ${file}...`);
-        await new Promise(resolve => setTimeout(resolve, 30));
-        logger.succeedSpinner(`${file} processed successfully`);
-      }
-
-      const { duplicateCount, finalLines } = countDuplicateLines(capturedOutput);
-      expect(duplicateCount).toBe(0);
-
-      // Each file should be processed exactly once
-      for (const file of files) {
-        const processedLines = finalLines.filter(line =>
-          line.includes(`${file} processed successfully`)
-        );
-        expect(processedLines.length).toBeLessThanOrEqual(1);
-      }
+      expect(allCalls.filter(call => String(call).includes('Success!')).length).toBeLessThanOrEqual(
+        1
+      );
+      expect(allCalls.filter(call => String(call).includes('Failed!')).length).toBeLessThanOrEqual(
+        1
+      );
+      expect(allCalls.filter(call => String(call).includes('Warning!')).length).toBeLessThanOrEqual(
+        1
+      );
     });
   });
 });

--- a/tests/spinner/prefix-and-artifacts.test.ts
+++ b/tests/spinner/prefix-and-artifacts.test.ts
@@ -1,6 +1,5 @@
 import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { Logger } from '../../src/logger';
-import { LogLevel } from '../../src/types';
 import { SpinnerUtils } from '../../src/utils/spinner';
 
 describe('Prefix and Artifacts Tests', () => {

--- a/tests/spinner/spinner-colors-integration.test.ts
+++ b/tests/spinner/spinner-colors-integration.test.ts
@@ -1,12 +1,16 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 import { DevLogrRenderer } from '../../src/devlogr-renderer';
+import { setupTestEnvironment } from '../helpers/test-environment';
 import chalk from 'chalk';
 
 describe('Spinner Colors Integration', () => {
   let renderer: DevLogrRenderer;
-  let mockTasks: any[];
+  let mockTasks: Array<Record<string, unknown>>;
 
   beforeEach(() => {
+    // Setup secure test environment with disabled colors
+    setupTestEnvironment(false, false, false, false); // Disable colors by default
+
     // Create mock tasks with different states
     mockTasks = [
       {
@@ -53,11 +57,14 @@ describe('Spinner Colors Integration', () => {
         output: null,
         message: { skip: 'Skipped for testing' },
       },
-    ] as any;
+    ];
   });
 
   it('should apply colors when useColors is enabled', () => {
-    renderer = new DevLogrRenderer(mockTasks, {
+    // Enable colors for this specific test
+    setupTestEnvironment(false, false, false, true); // Enable colors
+
+    renderer = new DevLogrRenderer(mockTasks as Parameters<typeof DevLogrRenderer>[0], {
       useColors: true,
       showTimestamp: false,
       supportsUnicode: true,
@@ -65,10 +72,10 @@ describe('Spinner Colors Integration', () => {
     });
 
     // Mock the spinner to return a symbol
-    (renderer as any).spinner = { fetch: () => '⠋' };
+    (renderer as Record<string, unknown>).spinner = { fetch: () => '⠋' };
 
     // Get the output by calling the private method
-    const output = (renderer as any).createOutput();
+    const output = (renderer as Record<string, unknown>).createOutput();
 
     // In CI environments, colors might be disabled, so check conditionally
     const hasColors =
@@ -83,7 +90,10 @@ describe('Spinner Colors Integration', () => {
   });
 
   it('should not apply colors when useColors is disabled', () => {
-    renderer = new DevLogrRenderer(mockTasks, {
+    // Ensure colors are disabled for this test
+    setupTestEnvironment(false, false, false, false); // Disable colors explicitly
+
+    renderer = new DevLogrRenderer(mockTasks as Parameters<typeof DevLogrRenderer>[0], {
       useColors: false,
       showTimestamp: false,
       supportsUnicode: true,
@@ -91,10 +101,10 @@ describe('Spinner Colors Integration', () => {
     });
 
     // Mock the spinner to return a symbol
-    (renderer as any).spinner = { fetch: () => '⠋' };
+    (renderer as Record<string, unknown>).spinner = { fetch: () => '⠋' };
 
     // Get the output by calling the private method
-    const output = (renderer as any).createOutput();
+    const output = (renderer as Record<string, unknown>).createOutput();
 
     // Verify that no ANSI color codes are present
     expect(output).not.toContain('\u001b['); // No ANSI escape sequences
@@ -105,7 +115,10 @@ describe('Spinner Colors Integration', () => {
   });
 
   it('should use correct color codes for each state', () => {
-    renderer = new DevLogrRenderer(mockTasks, {
+    // Enable colors for this specific test
+    setupTestEnvironment(false, false, false, true); // Enable colors
+
+    renderer = new DevLogrRenderer(mockTasks as Parameters<typeof DevLogrRenderer>[0], {
       useColors: true,
       showTimestamp: false,
       supportsUnicode: true,
@@ -113,10 +126,10 @@ describe('Spinner Colors Integration', () => {
     });
 
     // Mock the spinner to return a symbol
-    (renderer as any).spinner = { fetch: () => '⠋' };
+    (renderer as Record<string, unknown>).spinner = { fetch: () => '⠋' };
 
     // Get the output by calling the private method
-    const output = (renderer as any).createOutput();
+    const output = (renderer as Record<string, unknown>).createOutput();
 
     // In CI environments, colors might be disabled, so check conditionally
     const hasColors =
@@ -180,9 +193,9 @@ describe('Spinner Colors Integration', () => {
     });
 
     // Mock the spinner
-    (renderer as any).spinner = { fetch: () => '⠋' };
+    (renderer as Record<string, unknown>).spinner = { fetch: () => '⠋' };
 
-    const output = (renderer as any).createOutput();
+    const output = (renderer as Record<string, unknown>).createOutput();
 
     // In CI environments, colors might be disabled, so check conditionally
     const hasColors =

--- a/tests/spinner/spinner.test.ts
+++ b/tests/spinner/spinner.test.ts
@@ -50,7 +50,6 @@ describe('Spinner functionality', () => {
 
       SpinnerUtils.start('test', spinnerOptions);
 
-      // The updateText method should not throw
       expect(() => SpinnerUtils.updateText('test', 'Updated text')).not.toThrow();
     });
 
@@ -114,7 +113,6 @@ describe('Spinner functionality', () => {
 
     beforeEach(() => {
       logger = new Logger('test-spinner');
-      // Mock TTY support to enable spinners
       vi.spyOn(SpinnerUtils, 'supportsSpinners').mockReturnValue(true);
     });
 
@@ -213,7 +211,6 @@ describe('Spinner functionality', () => {
         logger.startSpinner('Second spinner');
       }).toThrow('A single spinner is already active. Ora only supports one spinner at a time.');
 
-      // Clean up
       logger.stopSpinner();
     });
 
@@ -224,7 +221,6 @@ describe('Spinner functionality', () => {
         logger.startSpinner('Second spinner');
       }).toThrow('A single spinner is already active. Ora only supports one spinner at a time.');
 
-      // Clean up
       logger.stopSpinner();
     });
 
@@ -232,7 +228,6 @@ describe('Spinner functionality', () => {
       logger.startSpinner('First spinner');
       logger.succeedSpinner('First completed');
 
-      // This should not throw
       expect(() => {
         logger.startSpinner('Second spinner');
       }).not.toThrow();
@@ -244,7 +239,6 @@ describe('Spinner functionality', () => {
       logger.startSpinner('First spinner');
       logger.stopSpinner();
 
-      // This should not throw
       expect(() => {
         logger.startSpinner('Second spinner');
       }).not.toThrow();
@@ -263,30 +257,24 @@ describe('Spinner functionality', () => {
     });
 
     it('should handle empty spinner text', () => {
-      // Should not throw and should use default text
       expect(() => logger.startSpinner()).not.toThrow();
 
-      // Should track spinner as active
       expect(logger.isSpinnerActive()).toBe(true);
 
-      // Clean up
       logger.stopSpinner();
     });
 
     it('should handle completion without starting spinner', () => {
       const successSpy = vi.spyOn(logger, 'success');
 
-      // Should not throw when completing without starting
       expect(() => {
         logger.succeedSpinner('Done');
       }).not.toThrow();
 
-      // Should fallback to regular logging
       expect(successSpy).toHaveBeenCalledWith('Done');
     });
 
     it('should handle multiple spinner operations', () => {
-      // Should not throw
       expect(() => {
         logger.startSpinner('First');
         logger.stopSpinner();
@@ -306,7 +294,6 @@ describe('Spinner functionality', () => {
     });
 
     it('should not attempt to clear non-existent spinners', () => {
-      // This should not throw
       expect(() => {
         logger.stopSpinner();
       }).not.toThrow();
@@ -314,7 +301,6 @@ describe('Spinner functionality', () => {
 
     it('should use multi-spinner infrastructure to prevent artifacts', () => {
       // The main goal is that single spinners now use multi-spinner infrastructure
-      // This should work without throwing and prevent artifacts
       expect(() => {
         logger.startSpinner('Processing...');
         logger.succeedSpinner('Done!');

--- a/tests/utils/emoji.test.ts
+++ b/tests/utils/emoji.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { createLogger, Logger } from '../../src/logger';
-import { LogLevel } from '../../src/types';
 import { SafeStringUtils } from '../../src/utils/safe-string';
 
 describe('Logger Emoji Handling', () => {

--- a/tests/utils/emoji.test.ts
+++ b/tests/utils/emoji.test.ts
@@ -16,15 +16,12 @@ describe('Logger Emoji Handling', () => {
       DEVLOGR_FORCE_COLOR: process.env.DEVLOGR_FORCE_COLOR,
     };
 
-    // Clear environment variables for clean slate
     Object.keys(originalEnv).forEach(key => {
       delete process.env[key];
     });
 
-    // Reset caches to ensure clean test state
     SafeStringUtils.resetCache();
 
-    // Reset logger level
     Logger.resetLevel();
   });
 
@@ -38,10 +35,8 @@ describe('Logger Emoji Handling', () => {
       }
     });
 
-    // Reset caches to ensure clean test state
     SafeStringUtils.resetCache();
 
-    // Reset logger level
     Logger.resetLevel();
   });
 
@@ -57,7 +52,6 @@ describe('Logger Emoji Handling', () => {
       expect(consoleSpy).toHaveBeenCalled();
       const output = consoleSpy.mock.calls[0][0];
 
-      // Should contain emojis
       expect(output).toContain('🚀');
       expect(output).toContain('🇺🇸');
       expect(output).toContain('Message with emoji 🚀 and flag 🇺🇸');
@@ -76,7 +70,6 @@ describe('Logger Emoji Handling', () => {
       expect(consoleSpy).toHaveBeenCalled();
       const output = consoleSpy.mock.calls[0][0];
 
-      // Should contain complex emojis
       expect(output).toContain('👨‍💻');
       expect(output).toContain('1️⃣');
 
@@ -96,10 +89,8 @@ describe('Logger Emoji Handling', () => {
       expect(consoleSpy).toHaveBeenCalled();
       const output = consoleSpy.mock.calls[0][0];
 
-      // Should NOT contain emojis
       expect(output).not.toContain('🚀');
       expect(output).not.toContain('🇺🇸');
-      // Should contain the text without emojis
       expect(output).toContain('Message with emoji');
       expect(output).toContain('and flag');
 
@@ -117,7 +108,6 @@ describe('Logger Emoji Handling', () => {
       expect(consoleSpy).toHaveBeenCalled();
       const output = consoleSpy.mock.calls[0][0];
 
-      // Should NOT contain complex emojis
       expect(output).not.toContain('👨‍💻');
       expect(output).not.toContain('1️⃣');
       expect(output).toContain('Complex emoji:');
@@ -137,7 +127,6 @@ describe('Logger Emoji Handling', () => {
       expect(consoleSpy).toHaveBeenCalled();
       const output = consoleSpy.mock.calls[0][0];
 
-      // Should NOT contain any emojis
       expect(output).not.toContain('🔥');
       expect(output).not.toContain('🎯');
       expect(output).not.toContain('✅');
@@ -180,7 +169,6 @@ describe('Logger Emoji Handling', () => {
       expect(consoleSpy).toHaveBeenCalled();
       const output = consoleSpy.mock.calls[0][0];
 
-      // Should be valid JSON
       expect(() => JSON.parse(output)).not.toThrow();
 
       const parsed = JSON.parse(output);
@@ -235,7 +223,6 @@ describe('Logger Emoji Handling', () => {
 
       const parsed = JSON.parse(output);
 
-      // Should strip all types of emojis
       expect(parsed.message).not.toContain('👨‍💻');
       expect(parsed.message).not.toContain('1️⃣');
       expect(parsed.message).not.toContain('🇺🇸');

--- a/tests/utils/emoji.test.ts
+++ b/tests/utils/emoji.test.ts
@@ -11,7 +11,7 @@ describe('Logger Emoji Handling', () => {
       NO_COLOR: process.env.NO_COLOR,
       DEVLOGR_NO_COLOR: process.env.DEVLOGR_NO_COLOR,
       NO_EMOJI: process.env.NO_EMOJI,
-      DEVLOGR_NO_EMOJI: process.env.DEVLOGR_NO_EMOJI,
+      DEVLOGR_SHOW_EMOJI: process.env.DEVLOGR_SHOW_EMOJI,
       DEVLOGR_OUTPUT_JSON: process.env.DEVLOGR_OUTPUT_JSON,
       DEVLOGR_FORCE_COLOR: process.env.DEVLOGR_FORCE_COLOR,
     };
@@ -97,8 +97,8 @@ describe('Logger Emoji Handling', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should strip emojis when DEVLOGR_NO_COLOR=true', () => {
-      process.env.DEVLOGR_NO_COLOR = 'true';
+    it('should strip emojis when DEVLOGR_SHOW_EMOJI=false', () => {
+      process.env.DEVLOGR_SHOW_EMOJI = 'false';
       const logger = createLogger('TEST');
 
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
@@ -136,8 +136,8 @@ describe('Logger Emoji Handling', () => {
       consoleSpy.mockRestore();
     });
 
-    it('should strip emojis when DEVLOGR_NO_EMOJI=1', () => {
-      process.env.DEVLOGR_NO_EMOJI = '1';
+    it('should strip emojis when DEVLOGR_SHOW_EMOJI=false', () => {
+      process.env.DEVLOGR_SHOW_EMOJI = 'false';
       const logger = createLogger('TEST');
 
       const consoleSpy = vi.spyOn(console, 'log').mockImplementation(() => {});

--- a/tests/utils/safe-string.test.ts
+++ b/tests/utils/safe-string.test.ts
@@ -16,7 +16,7 @@ describe('SafeStringUtils', () => {
     delete process.env.DEVLOGR_NO_UNICODE;
     delete process.env.DEVLOGR_UNICODE;
     delete process.env.NO_EMOJI;
-    delete process.env.DEVLOGR_NO_EMOJI;
+    delete process.env.DEVLOGR_SHOW_EMOJI;
     SafeStringUtils.resetCache();
   });
 

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -166,7 +166,7 @@ describe('EmojiUtils', () => {
     });
   });
 
-  describe('stripEmojisAndFixSpaces', () => {
+  describe('processEmojisAndFixSpaces', () => {
     it('should handle multiple spaces correctly when emojis are present', () => {
       const result = EmojiUtils.format('Hello 🚀   world   test');
       // When emoji support is disabled, spaces should be cleaned up

--- a/tests/utils/utils.test.ts
+++ b/tests/utils/utils.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { StringUtils, EmojiUtils, TerminalUtils, SafeStringUtils } from '../../src/utils';
+import { describe, it, expect } from 'vitest';
+import { StringUtils, EmojiUtils, TerminalUtils } from '../../src/utils';
 
 describe('StringUtils', () => {
   describe('formatTime', () => {
@@ -65,7 +65,7 @@ describe('StringUtils', () => {
 
     it('should handle edge cases', () => {
       expect(StringUtils.truncate('', 10)).toBe('');
-      expect(StringUtils.truncate('test', 0)).toMatch(/^(\.\.\.|\…)$/);
+      expect(StringUtils.truncate('test', 0)).toMatch(/^(\.\.\.|…)$/);
     });
   });
 
@@ -81,7 +81,7 @@ describe('StringUtils', () => {
     });
 
     it('should handle circular references', () => {
-      const obj: any = { name: 'test' };
+      const obj: Record<string, unknown> = { name: 'test' };
       obj.self = obj;
 
       const result = StringUtils.safeJsonStringify(obj);


### PR DESCRIPTION
…imestamp in CI

- Fix DevLogrRenderer to respect renderer options for prefix display
- Remove dependency on global config.showPrefix for spinner tasks
- Change default taskLevel from 'plain' to 'task' for better semantics
- Ensure Logger-passed showTimestamp and prefix options are honored
- Show proper TASK level label instead of generic PLAIN for spinners
- Maintain proper timestamp and prefix formatting in CI environments
- All 345 tests passing with improved CI spinner behavio